### PR TITLE
Use app.registered instead of app.activated

### DIFF
--- a/doc/source/sdk/v1/iframes_in_apps.md
+++ b/doc/source/sdk/v1/iframes_in_apps.md
@@ -17,7 +17,8 @@ Start by adding the following code to your website:
 
   app.postMessage('hello', { foo: true }); // post the message 'hello' to the Zendesk app
 
-  app.on('app.activated', function(data) { // listen to the 'app.activated' Framework event
+  // listen to the 'app.registered' event, which is fired by the framework once the iframe is registered with the app
+  app.on('app.registered', function(data) {
     // go nuts
   });
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -62,7 +62,7 @@ Client.prototype = {
   ///
   /// ```javascript
   /// var client = ZAFClient.init();
-  /// client.on('app.activated', function(e) {
+  /// client.on('app.registered', function(e) {
   ///   // go nuts
   /// });
   /// ```
@@ -89,9 +89,9 @@ Client.prototype = {
   /// ```javascript
   /// var client = ZAFClient.init();
   ///
-  /// client.on('app.activated', function appActivated(e) {
+  /// client.on('app.registered', function appRegistered(e) {
   ///   // do stuff then remove the handler
-  ///   client.off('app.activated', appActivated);
+  ///   client.off('app.registered', appRegistered);
   /// });
   /// ```
   off: function(name, handler) {
@@ -112,12 +112,12 @@ Client.prototype = {
   /// ```javascript
   /// var client = ZAFClient.init();
   ///
-  /// client.on('app.activated', function appActivated(e) {
+  /// client.on('app.registered', function appRegistered(e) {
   ///   // do stuff
   /// });
   ///
-  /// client.has('app.activated', appActivated);   // true
-  /// client.has('app.deactivated', appActivated); // false
+  /// client.has('app.registered', appRegistered); // true
+  /// client.has('app.activated', appRegistered); // false
   /// ```
   has: function(name, handler) {
     if (!this._messageHandlers[name]) { return false; }


### PR DESCRIPTION
:koala:

The docs included examples of listening to the `app.activated` event. This was confusing for app developers, because by the time the iframe is loaded the `app.activated` event has already fired. This PR changes examples to use `app.registered` instead, which is fired by the framework once the iframe is registered with the app.

/cc @zendesk/quokka

### Risks
 - None