### PR TITLE
window.parent instead of top

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -82,7 +82,7 @@ function messageHandler(client, event) {
 
 var Client = function(origin, appGuid) {
   this._origin = origin;
-  this._source = window.top;
+  this._source = window.parent;
   this._appGuid = appGuid;
   this._messageHandlers = {};
   this._metadata = null;


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description
.parent instead of .top


### References
* JIRA: 

### Risks
- framwork sdk stops working because it can't connect anymore