### PR TITLE
Ability to pass what window we want to link with!

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -80,9 +80,9 @@ function messageHandler(client, event) {
   }
 }
 
-var Client = function(origin, appGuid) {
+var Client = function(origin, appGuid, source) {
   this._origin = origin;
-  this._source = window.parent;
+  this._source = source || window.parent;
   this._appGuid = appGuid;
   this._messageHandlers = {};
   this._metadata = null;

--- a/lib/client.js
+++ b/lib/client.js
@@ -82,7 +82,7 @@ function messageHandler(client, event) {
 
 var Client = function(origin, appGuid, source) {
   this._origin = origin;
-  this._source = source || window.parent;
+  this._source = typeof source === 'object' ? source : window.parent;
   this._appGuid = appGuid;
   this._messageHandlers = {};
   this._metadata = null;

--- a/lib/index.js
+++ b/lib/index.js
@@ -24,13 +24,16 @@ var Client    = require('client'),
 ///   console.log('Hi ' + currentUser.name);
 /// });
 /// ```
-ZAFClient.init = function(callback) {
+ZAFClient.init = function(sourceOrCallback, callback) {
   var params = Utils.queryParameters(),
-      client;
+      client,
+      source = callback ? sourceOrCallback : undefined;
+
+  callback = callback || sourceOrCallback;
 
   if (!params.origin || !params.app_guid) { return false; }
 
-  client = new Client(params.origin, params.app_guid);
+  client = new Client(params.origin, params.app_guid, source);
 
   if (typeof callback === 'function') {
     client.on('app.registered', callback.bind(client));

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,32 +6,42 @@ var Client    = require('client'),
 ///
 /// When you include the ZAF SDK on your website, you get access to the `ZAFClient` object.
 ///
-/// #### ZAFClient.init([callback(context)])
+/// #### ZAFClient.init([source], [callback(context)])
 ///
 /// Returns a [`client`](#client-object) object.
 ///
 /// ##### Arguments
+///   The arguments can be either nothing, a source, a callback, or a source and callback.
 ///
 ///   * `callback(context)` (optional) a function called as soon as communication with
 ///     the Zendesk app is established. The callback receives a context object with
 ///     data related to the Zendesk app, including `currentAccount`, `currentUser`, and `location`
+///   * `source` (optional) a window object with ZendeskApps, to control what window we are
+///     connecting to.
 ///
-/// Example:
+/// Examples:
 ///
 /// ```javascript
-/// var client = ZAFClient.init(function(context) {
+/// var client = ZAFClient.init();
+///
+/// client = ZAFClient.init(function(context) {
 ///   var currentUser = context.currentUser;
 ///   console.log('Hi ' + currentUser.name);
 /// });
+///
+/// client = ZAFClient.init(window.parent);
+///
+/// client = ZAFClient.init(window.parent, function(context) {});
 /// ```
 ZAFClient.init = function(sourceOrCallback, callback) {
   var params = Utils.queryParameters(),
       client,
-      source = callback ? sourceOrCallback : undefined;
+      source = typeof sourceOrCallback === 'object' ? sourceOrCallback : undefined;
+
+  // if callback is present but not a function the user likely switched the arguments
+  if (!params.origin || !params.app_guid || typeof callback === 'object') { return false; }
 
   callback = callback || sourceOrCallback;
-
-  if (!params.origin || !params.app_guid) { return false; }
 
   client = new Client(params.origin, params.app_guid, source);
 

--- a/spec/index_spec.js
+++ b/spec/index_spec.js
@@ -14,6 +14,8 @@ describe('ZAFClient', function() {
 
   describe('.init', function() {
     describe('given origin and app_guid exist', function() {
+      var client;
+
       beforeEach(function() {
         Utils.queryParameters.returns({
           origin: document.location,
@@ -27,7 +29,7 @@ describe('ZAFClient', function() {
 
         beforeEach(function() {
           sandbox.spy(Client.prototype, 'on');
-          ZAFClient.init(callback);
+          client = ZAFClient.init(callback);
         });
 
         it('binds the callback to app.registered', function() {
@@ -36,6 +38,53 @@ describe('ZAFClient', function() {
             return cb === callback;
           }, 'wrong callback');
           expect(Client.prototype.on).to.have.been.calledWith('app.registered', callbackMatcher);
+          expect(client._source).to.equal(window.parent);
+        });
+      });
+
+      describe('when a source is passed', function() {
+        var fakeWindow = { postMessage: function() {} };
+
+        beforeEach(function() {
+          client = ZAFClient.init( fakeWindow );
+        });
+
+        it('stores the correct source to the client', function() {
+          expect(client._source).to.equal(fakeWindow);
+        });
+      });
+
+      describe('when a source and callback are passed', function() {
+        var callback = function() { return 'abcxyz'; },
+            fakeWindow = { postMessage: function() {} };
+
+        callback.bind = function() { return callback; };
+
+        beforeEach(function() {
+          sandbox.spy(Client.prototype, 'on');
+          client = ZAFClient.init(fakeWindow, callback);
+        });
+
+        it('stores the correct source to the client and binds the callback to app.registered', function() {
+          var callbackMatcher = sinon.match(function (cb) {
+            // performs an identity check, meaning that bind must be stubbed to return the same method
+            return cb === callback;
+          }, 'wrong callback');
+          expect(Client.prototype.on).to.have.been.calledWith('app.registered', callbackMatcher);
+          expect(client._source).to.equal(fakeWindow);
+        });
+      });
+
+      describe('when a callback and source are passed', function() {
+        var callback = function() { return 'abcxyz'; },
+            fakeWindow = { postMessage: function() {} };
+
+        beforeEach(function() {
+          client = ZAFClient.init(callback, fakeWindow);
+        });
+
+        it('errors', function() {
+          expect(client).to.equal(false);
         });
       });
     });


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite
### Description

ability to pass the source of the window

So insteaf of doing this:
`zafClient.init();`

you could do this to bind to a certain level of the framework. Which means you could potentially create apps in zopim that talk to the zopim layer AND the zendesk layer!
`zafClient.init( window.parent.parent );`
### References
- JIRA: 
### Risks
