### PR TITLE
[BUG] Fixes an issue where Save Hook rules aren't being respect for synchronous return

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -88,9 +88,7 @@ function when(items) {
         } else if (isFalsy(res)) {
           promise = Promise.reject(res);
         } else {
-          promise = new Promise(function(resolve) {
-            resolve(res);
-          });
+          promise = Promise.resolve(res);
         }
       } catch(err) {
         promise = Promise.reject(err);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -85,15 +85,15 @@ function when(items) {
         res = item();
         if (isPromise(res)) {
           promise = res;
+        } else if (isFalsy(res)) {
+          promise = Promise.reject(res);
         } else {
           promise = new Promise(function(resolve) {
             resolve(res);
           });
         }
       } catch(err) {
-        promise = new Promise(function(resolve, reject) {
-          reject(err);
-        });
+        promise = Promise.reject(err);
       }
     } else {
       promise = new Promise(function(resolve, reject) {

--- a/spec/utils_spec.js
+++ b/spec/utils_spec.js
@@ -56,6 +56,22 @@ describe('Utils', function() {
 
     });
 
+    describe('with one or more functions passed in', function() {
+      it('should reject when any of the functions returns false', function(done) {
+        expect(Utils.when([
+          function() { return false; },
+          function() { return true; }
+        ])).to.eventually.be.rejected.and.notify(done);
+      });
+
+      it('should reject with a string, when any of the functions returns a string', function(done) {
+        expect(Utils.when([
+          function() { return 'Awful mistake'; },
+          function() { return true; }
+        ])).to.eventually.be.rejectedWith('Awful mistake').and.notify(done);
+      });
+    });
+
     describe('with one or more promises passed in', function() {
       var allDone;
       beforeEach(function() {

--- a/spec/utils_spec.js
+++ b/spec/utils_spec.js
@@ -70,6 +70,13 @@ describe('Utils', function() {
           function() { return true; }
         ])).to.eventually.be.rejectedWith('Awful mistake').and.notify(done);
       });
+
+      it('should resolve if all of the functions return true', function(done) {
+        expect(Utils.when([
+          function() { return true; },
+          function() { return true; }
+        ])).to.eventually.be.fulfilled.and.notify(done);
+      });
     });
 
     describe('with one or more promises passed in', function() {


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description

Where a Save Hook handler was returning immediately, rather than a Promise, the rules governing Save Hook return values weren't being respected.

### TODO
- [x] ~~Add regression test~~ 04a8150 59a7ac7

### Risks
* [low] Save Hook allowing Ticket Save when not intended, or vice-versa