### PR TITLE
Add subscriber count to iframe event handler events

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,9 @@ node_js:
   - '0.10'
 before_script:
   - npm install -g grunt-cli
+sudo: false
+cache:
+  directories:
+    - node_modules
+branches:
+  only: [master]

--- a/lib/client.js
+++ b/lib/client.js
@@ -248,7 +248,9 @@ Client.prototype = {
     if (this._parent) { throw new Error('Not Implemented'); }
     if (!this._messageHandlers[name]) { return false; }
     var index = this._messageHandlers[name].indexOf(handler);
-    this._messageHandlers[name].splice(index, 1);
+    if (this.has(name, handler)) {
+      this._messageHandlers[name].splice(index, 1);
+    }
 
     // Subscriber count is needed as the framework will only unbind events on the last detached handler (count of 0)
     this.postMessage('iframe.off:' + name, { subscriberCount: this._messageHandlers[name].length });

--- a/lib/client.js
+++ b/lib/client.js
@@ -221,7 +221,8 @@ Client.prototype = {
       this._messageHandlers[name].push(handler);
 
       if (name !== 'app.registered') {
-        this.postMessage('iframe.on:' + name);
+        // Subscriber count is needed as the framework will only bind events on the first attached handler
+        this.postMessage('iframe.on:' + name, { subscriberCount: this._messageHandlers[name].length });
       }
     }
   },
@@ -247,8 +248,11 @@ Client.prototype = {
     if (this._parent) { throw new Error('Not Implemented'); }
     if (!this._messageHandlers[name]) { return false; }
     var index = this._messageHandlers[name].indexOf(handler);
-    this.postMessage('iframe.off:' + name);
-    return this._messageHandlers[name].splice(index, 1)[0];
+    this._messageHandlers[name].splice(index, 1);
+
+    // Subscriber count is needed as the framework will only unbind events on the last detached handler (count of 0)
+    this.postMessage('iframe.off:' + name, { subscriberCount: this._messageHandlers[name].length });
+    return handler;
   },
 
   /// #### client.has(name, handler)

--- a/spec/client_spec.js
+++ b/spec/client_spec.js
@@ -156,6 +156,12 @@ describe('Client', function() {
         expect(subject._messageHandlers.foo).to.not.exist;
       });
 
+      it('notifies the framework of the handler registration', function() {
+        sandbox.spy(subject, 'postMessage');
+        subject.on('foo', callback);
+        expect(subject.postMessage).to.have.been.calledWithMatch('iframe.on:foo', { subscriberCount: 1 });
+      });
+
     });
 
     describe('#off', function() {
@@ -174,6 +180,13 @@ describe('Client', function() {
 
       it('returns false if no handler was found', function() {
         expect(subject.off('foo', callback)).to.be.false;
+      });
+
+      it('notifies the framework of the handler removal', function() {
+        sandbox.spy(subject, 'postMessage');
+        subject.on('foo', callback);
+        subject.off('foo', callback);
+        expect(subject.postMessage).to.have.been.calledWithMatch('iframe.off:foo', { subscriberCount: 0 });
       });
 
     });

--- a/spec/client_spec.js
+++ b/spec/client_spec.js
@@ -188,7 +188,22 @@ describe('Client', function() {
         subject.off('foo', callback);
         expect(subject.postMessage).to.have.been.calledWithMatch('iframe.off:foo', { subscriberCount: 0 });
       });
+      describe('when #off is called before #on', function() {
+        beforeEach(function() {
+          sandbox.spy(subject, 'postMessage');
+          subject.on('foo', function() {});
+        });
 
+        it('notifies the framework of the handler removal', function() {
+          subject.off('foo', callback);
+          expect(subject.postMessage).to.have.been.calledWithMatch('iframe.off:foo', { subscriberCount: 1 });
+        });
+
+        it('does not remove other handlers', function() {
+          subject.off('foo', callback);
+          expect(subject._messageHandlers.foo.length).to.equal(1);
+        });
+      });
     });
 
     describe('#has', function() {


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description
Add subscriber count to iframe event handler events.
This allows the framework to know how many subscribers are listening inside the iframe, and when it's safe to bind/unbind.

### References
* JIRA: 

### Risks
* low: data attribute of event is unused