### PR TITLE
[AF-359] Add support for binding and triggering events across instances

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -90,7 +90,7 @@ function triggerEvent(client, eventName, data) {
   });
 }
 
-function finalisePendingPromise(pendingPromise, data) {
+function finalizePendingPromise(pendingPromise, data) {
   if (data.error) {
     var error = data.error.name ? createError(data.error) : data.error;
     pendingPromise.reject(error);
@@ -142,7 +142,7 @@ function messageHandler(client, event) {
       pendingPromise;
 
   if (data.id && (pendingPromise = pendingPromises[data.id])) {
-    finalisePendingPromise(pendingPromise, data);
+    finalizePendingPromise(pendingPromise, data);
   } else if (ZAF_EVENT.test(data.key)) {
     var key = data.key.replace(ZAF_EVENT, ''),
         msg = { appGuid: client._appGuid };

--- a/lib/client.js
+++ b/lib/client.js
@@ -391,6 +391,7 @@ Client.prototype = {
   },
 
   instance: function(instanceGuid) {
+    if (instanceGuid === this._instanceGuid) { return this; }
     if (this._parent) { return this._parent.instance(instanceGuid); }
     var instanceClient = this._instanceClients[instanceGuid];
     if (!instanceClient) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -98,6 +98,8 @@ function messageHandler(client, event) {
     }
   }
 
+  if (data.instanceGuid && data.instanceGuid !== client._instanceGuid) { return; }
+
   var pendingPromise;
   if (data.id && (pendingPromise = pendingPromises[data.id])) {
     if (data.error) {
@@ -124,7 +126,10 @@ function messageHandler(client, event) {
         delete client._repliesPending[key];
       });
     } else {
-      client.trigger(key, data.message);
+      if (!client._messageHandlers[key]) { return; }
+      client._messageHandlers[key].forEach(function(handler) {
+        handler(data.message);
+      });
     }
   }
 }
@@ -159,11 +164,6 @@ var Client = function(options) {
   this._context = options.context || null;
   this.ready = false;
 
-  if (this._parent) {
-    this.ready = this._parent.ready;
-    return this; // shortcut handshake
-  }
-
   this.on('app.registered', function(data) {
     this.ready = true;
     this._metadata = data.metadata;
@@ -174,9 +174,14 @@ var Client = function(options) {
     this._context = context;
   }, this);
 
-  this.postMessage('iframe.handshake', { version: version });
-
   window.addEventListener('message', messageHandler.bind(null, this));
+
+  if (this._parent) {
+    this.ready = this._parent.ready;
+    return this; // shortcut handshake
+  }
+
+  this.postMessage('iframe.handshake', { version: version });
 };
 
 Client.prototype = {
@@ -200,7 +205,6 @@ Client.prototype = {
   /// client.postMessage('hello', { awesome: true });
   /// ```
   postMessage: function(name, data) {
-    if (this._parent) { throw new Error('Not Implemented'); }
     var msg = JSON.stringify({ key: name, message: data, appGuid: this._appGuid, instanceGuid: this._instanceGuid });
     rawPostMessage(this, msg, name === 'iframe.handshake');
   },
@@ -231,7 +235,6 @@ Client.prototype = {
   /// `app.registered` event. You can add as many handlers to `app.registered` as you like. They're
   /// called immediately after the `init` callback.
   on: function(name, handler, context) {
-    if (this._parent) { throw new Error('Not Implemented'); }
     if (typeof handler == 'function') {
       handler = context ?
         handler.bind(context) :
@@ -297,7 +300,6 @@ Client.prototype = {
   /// client.has('app.activated', appRegistered); // false
   /// ```
   has: function(name, handler) {
-    if (this._parent) { throw new Error('Not Implemented'); }
     if (!this._messageHandlers[name]) { return false; }
     return this._messageHandlers[name].indexOf(handler) !== -1;
   },
@@ -321,11 +323,7 @@ Client.prototype = {
   /// client.trigger('activation') // activating!
   /// ```
   trigger: function(name, data) {
-    if (this._parent) { throw new Error('Not Implemented'); }
-    if (!this._messageHandlers[name]) { return false; }
-    this._messageHandlers[name].forEach(function(handler) {
-      handler(data);
-    });
+    this.postMessage('iframe.trigger:' + name, { message: data });
   },
 
   /// #### client.request(options)
@@ -400,21 +398,21 @@ Client.prototype = {
   },
 
   context: function() {
-    if (this._instanceGuid && this._instanceGuid != this._appGuid) {
-      var key = 'instances.' + this._instanceGuid;
-      return this.get(key).then(function(data) {
-        this._context = data[key];
-        return this._context;
-      }.bind(this));
-    }
-
     return new Promise(function(resolve) {
       if (this._context) {
         resolve(this._context);
       } else {
-        this.on('app.registered', function() {
-          resolve(this._context);
-        }.bind(this));
+        if (this._instanceGuid && this._instanceGuid != this._appGuid) {
+          var key = 'instances.' + this._instanceGuid;
+          return this.get(key).then(function(data) {
+            this._context = data[key];
+            return this._context;
+          }.bind(this));
+        } else {
+          this.on('app.registered', function() {
+            resolve(this._context);
+          }.bind(this));
+        }
       }
     }.bind(this));
   },

--- a/lib/client.js
+++ b/lib/client.js
@@ -417,23 +417,23 @@ Client.prototype = {
   },
 
   context: function() {
-    return new Promise(function(resolve) {
-      if (this._context) {
-        resolve(this._context);
+    if (this._context) {
+      return Promise.resolve(this._context);
+    } else {
+      if (this._instanceGuid && this._instanceGuid != this._appGuid) {
+        var key = 'instances.' + this._instanceGuid;
+        return this.get(key).then(function(data) {
+          this._context = data[key];
+          return this._context;
+        }.bind(this));
       } else {
-        if (this._instanceGuid && this._instanceGuid != this._appGuid) {
-          var key = 'instances.' + this._instanceGuid;
-          return this.get(key).then(function(data) {
-            this._context = data[key];
-            return this._context;
-          }.bind(this));
-        } else {
-          this.on('app.registered', function() {
-            resolve(this._context);
-          }.bind(this));
-        }
+        return new Promise(function(resolve) {
+          this.on('app.registered', function(data) {
+            resolve(data.context);
+          });
+        }.bind(this));
       }
-    }.bind(this));
+    }
   },
 
   // Accepts string or array of strings.

--- a/lib/client.js
+++ b/lib/client.js
@@ -90,7 +90,7 @@ function triggerEvent(client, eventName, data) {
   });
 }
 
-function handlePendingPromise(pendingPromise, data) {
+function finalisePendingPromise(pendingPromise, data) {
   if (data.error) {
     var error = data.error.name ? createError(data.error) : data.error;
     pendingPromise.reject(error);
@@ -142,7 +142,7 @@ function messageHandler(client, event) {
       pendingPromise;
 
   if (data.id && (pendingPromise = pendingPromises[data.id])) {
-    handlePendingPromise(pendingPromise, data);
+    finalisePendingPromise(pendingPromise, data);
   } else if (ZAF_EVENT.test(data.key)) {
     var key = data.key.replace(ZAF_EVENT, ''),
         msg = { appGuid: client._appGuid };

--- a/lib/client.js
+++ b/lib/client.js
@@ -99,7 +99,7 @@ function finalisePendingPromise(pendingPromise, data) {
   }
 }
 
-function postReply(client, key, msg) {
+function postReplyWith(client, key, msg) {
   if (client._repliesPending[key]) { return; }
   msg.key = 'iframe.reply:' + key;
   client._repliesPending[key] = true;
@@ -148,7 +148,7 @@ function messageHandler(client, event) {
         msg = { appGuid: client._appGuid };
 
     if (data.needsReply) {
-      postReply(clientRecipient, key, msg);
+      postReplyWith(clientRecipient, key, msg);
     } else {
       triggerEvent(clientRecipient, key, data.message);
     }

--- a/lib/client.js
+++ b/lib/client.js
@@ -375,16 +375,15 @@ Client.prototype = {
 
   instance: function(instanceGuid) {
     if (this._parent) { return this._parent.instance(instanceGuid); }
-    var instanceContextKey = 'instances.' + instanceGuid;
-    this._instanceClients[instanceGuid] = this._instanceClients[instanceGuid] ||
-      this.get(instanceContextKey).then(function(data) {
-        return new Client({
-          parent: this,
-          instanceGuid: instanceGuid,
-          context: data[instanceContextKey]
-        });
-      }.bind(this));
-    return this._instanceClients[instanceGuid];
+    var instanceClient = this._instanceClients[instanceGuid];
+    if (!instanceClient) {
+      instanceClient = new Client({
+        parent: this,
+        instanceGuid: instanceGuid
+      });
+      this._instanceClients[instanceGuid] = instanceClient;
+    }
+    return instanceClient;
   },
 
   metadata: function() {

--- a/lib/client.js
+++ b/lib/client.js
@@ -90,10 +90,6 @@ function triggerEvent(client, eventName, data) {
   });
 }
 
-function isIntendedRecipient(recipientGuid, clientGuid) {
-  return recipientGuid && recipientGuid !== clientGuid;
-}
-
 function handlePendingPromise(pendingPromise, data) {
   if (data.error) {
     var error = data.error.name ? createError(data.error) : data.error;
@@ -119,6 +115,14 @@ function postReply(client, key, msg) {
   });
 }
 
+function getMessageRecipient(client, recipientGuid) {
+  if (recipientGuid && recipientGuid !== client._instanceGuid) {
+    return client._instanceClients[recipientGuid];
+  }
+
+  return client;
+}
+
 function messageHandler(client, event) {
   if (!isValidEvent(client, event)) { return; }
 
@@ -134,19 +138,19 @@ function messageHandler(client, event) {
     }
   }
 
-  if (!isIntendedRecipient(data.instanceGuid, client._instanceGuid)) { return; }
+  var clientRecipient = getMessageRecipient(client, data.instanceGuid),
+      pendingPromise;
 
-  var pendingPromise;
-  if (data.id && pendingPromises[data.id]) {
+  if (data.id && (pendingPromise = pendingPromises[data.id])) {
     handlePendingPromise(pendingPromise, data);
   } else if (ZAF_EVENT.test(data.key)) {
     var key = data.key.replace(ZAF_EVENT, ''),
         msg = { appGuid: client._appGuid };
 
     if (data.needsReply) {
-      postReply(client, key, msg);
+      postReply(clientRecipient, key, msg);
     } else {
-      triggerEvent(client, key, data.message);
+      triggerEvent(clientRecipient, key, data.message);
     }
   }
 }
@@ -191,13 +195,12 @@ var Client = function(options) {
     this._context = context;
   }, this);
 
-  window.addEventListener('message', messageHandler.bind(null, this));
-
   if (this._parent) {
     this.ready = this._parent.ready;
     return this; // shortcut handshake
   }
 
+  window.addEventListener('message', messageHandler.bind(null, this));
   this.postMessage('iframe.handshake', { version: version });
 };
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -90,6 +90,35 @@ function triggerEvent(client, eventName, data) {
   });
 }
 
+function isIntendedRecipient(recipientGuid, clientGuid) {
+  return recipientGuid && recipientGuid !== clientGuid;
+}
+
+function handlePendingPromise(pendingPromise, data) {
+  if (data.error) {
+    var error = data.error.name ? createError(data.error) : data.error;
+    pendingPromise.reject(error);
+  } else {
+    pendingPromise.resolve(data.result);
+  }
+}
+
+function postReply(client, key, msg) {
+  if (client._repliesPending[key]) { return; }
+  msg.key = 'iframe.reply:' + key;
+  client._repliesPending[key] = true;
+  when(client._messageHandlers[key]).then(
+    rawPostMessage.bind(null, client, msg)
+  ).catch(function(reason) {
+    msg.error = {
+      msg: reason
+    };
+    rawPostMessage(client, msg);
+  }).then(function() {
+    delete client._repliesPending[key];
+  });
+}
+
 function messageHandler(client, event) {
   if (!isValidEvent(client, event)) { return; }
 
@@ -105,33 +134,17 @@ function messageHandler(client, event) {
     }
   }
 
-  if (data.instanceGuid && data.instanceGuid !== client._instanceGuid) { return; }
+  if (!isIntendedRecipient(data.instanceGuid, client._instanceGuid)) { return; }
 
   var pendingPromise;
-  if (data.id && (pendingPromise = pendingPromises[data.id])) {
-    if (data.error) {
-      var error = data.error.name ? createError(data.error) : data.error;
-      pendingPromise.reject(error);
-    } else {
-      pendingPromise.resolve(data.result);
-    }
+  if (data.id && pendingPromises[data.id]) {
+    handlePendingPromise(pendingPromise, data);
   } else if (ZAF_EVENT.test(data.key)) {
     var key = data.key.replace(ZAF_EVENT, ''),
         msg = { appGuid: client._appGuid };
+
     if (data.needsReply) {
-      if (client._repliesPending[key]) { return; }
-      msg.key = 'iframe.reply:' + key;
-      client._repliesPending[key] = true;
-      when(client._messageHandlers[key]).then(
-        rawPostMessage.bind(null, client, msg)
-      ).catch(function(reason) {
-        msg.error = {
-          msg: reason
-        };
-        rawPostMessage(client, msg);
-      }).then(function() {
-        delete client._repliesPending[key];
-      });
+      postReply(client, key, msg);
     } else {
       triggerEvent(client, key, data.message);
     }

--- a/lib/client.js
+++ b/lib/client.js
@@ -116,11 +116,17 @@ function postReplyWith(client, key, msg) {
 }
 
 function getMessageRecipient(client, recipientGuid) {
+  var messageRecipient = client;
+
   if (recipientGuid && recipientGuid !== client._instanceGuid) {
-    return client._instanceClients[recipientGuid];
+    messageRecipient = client._instanceClients[recipientGuid];
+
+    if (!messageRecipient) {
+      throw Error('[ZAF SDK] Could not find client for instance ' + recipientGuid);
+    }
   }
 
-  return client;
+  return messageRecipient;
 }
 
 function messageHandler(client, event) {

--- a/spec/client_spec.js
+++ b/spec/client_spec.js
@@ -542,32 +542,21 @@ describe('Client', function() {
       });
 
       it('requests instance context and caches it in the returned client', function() {
-        promise = subject.instance('def-321');
-        expect(subject.get).to.have.been.calledWith('instances.def-321');
-        return Promise.all([
-          expect(promise).to.eventually.be.an.instanceof(Client),
-          expect(promise).to.eventually.have.property('_context').that.equals(context),
-          expect(promise).to.eventually.have.property('_instanceGuid').that.equals('def-321')
-        ]);
+        var instanceClient = subject.instance('def-321');
+        expect(instanceClient).to.be.an.instanceof(Client);
+        expect(instanceClient).to.have.property('_instanceGuid').that.equals('def-321');
       });
 
       it('returns the same client when requested multiple times', function() {
-        return Promise.all([
-          subject.instance('def-321'),
-          subject.instance('def-321')
-        ]).then(function(promises) {
-          expect(promises[0]).to.equal(promises[1]);
-        });
+        expect(subject.instance('def-321')).to.equal(subject.instance('def-321'));
       });
 
       describe('with the returned client', function() {
         var childClient;
 
-        beforeEach(function(done) {
-          subject.instance('def-321').then(function(client) {
-            childClient = client;
-            window.top.postMessage.reset();
-          }).then(done);
+        beforeEach(function() {
+          childClient = subject.instance('def-321');
+          window.top.postMessage.reset();
         });
 
         it('should be ready', function() {

--- a/spec/client_spec.js
+++ b/spec/client_spec.js
@@ -608,6 +608,10 @@ describe('Client', function() {
         expect(subject.instance('def-321')).to.equal(subject.instance('def-321'));
       });
 
+      it('returns its own client if the instanceGuid is matches its own', function() {
+        expect(subject.instance(subject._instanceGuid)).to.equal(subject);
+      });
+
       describe('with the returned client', function() {
         var childClient;
 

--- a/spec/client_spec.js
+++ b/spec/client_spec.js
@@ -568,17 +568,9 @@ describe('Client', function() {
       describe('with the returned client', function() {
         var childClient;
 
-<<<<<<< HEAD
         beforeEach(function() {
           childClient = subject.instance('def-321');
-          window.top.postMessage.reset();
-=======
-        beforeEach(function(done) {
-          subject.instance('def-321').then(function(client) {
-            childClient = client;
-            source.postMessage.reset();
-          }).then(done);
->>>>>>> adammw/instances-event-apis
+          source.postMessage.reset();
         });
 
         it('should be ready', function() {

--- a/spec/client_spec.js
+++ b/spec/client_spec.js
@@ -594,17 +594,11 @@ describe('Client', function() {
     });
 
     describe('#instance', function() {
-      var context = { location: 'top_bar' };
-
       beforeEach(function() {
         subject.ready = true;
-        sandbox.stub(subject, 'get');
-        subject.get.withArgs('instances.def-321').returns(
-          Promise.resolve({ 'instances.def-321': context })
-        );
       });
 
-      it('requests instance context and caches it in the returned client', function() {
+      it('returns a client for the instance', function() {
         var instanceClient = subject.instance('def-321');
         expect(instanceClient).to.be.an.instanceof(Client);
         expect(instanceClient).to.have.property('_instanceGuid').that.equals('def-321');
@@ -631,6 +625,8 @@ describe('Client', function() {
         });
 
         describe('#context', function() {
+          var context = { location: 'top_bar' };
+
           it('delegates to instances api', function() {
             sandbox.stub(childClient, 'get').withArgs('instances.def-321').returns(
               Promise.resolve({ 'instances.def-321': context })


### PR DESCRIPTION
:v:

✅  _Depends on https://github.com/zendesk/zendesk_app_framework/pull/622_

/cc @zendesk/vegemite

### Description
Add support for binding and triggering events across instances. This PR also changes the `instance` API to return a client rather than a promise that resolves with a client. See discussion [here](https://github.com/zendesk/zendesk_app_framework_sdk/pull/25/files#r71476024).

### Tasks
- [x] Write tests

### References
* JIRA: https://zendesk.atlassian.net/browse/AF-359

### Risks
* [low] instances API may not work as intended.