### PR TITLE
Send caught error responses when replying

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,20 @@
 language: node_js
 node_js:
   - '6.3.0'
+before_install:
+  - export PATH=$PWD/travis_phantomjs/phantomjs-$PHANTOMJS_VERSION-linux-x86_64/bin:$PATH
+  - if [ $(phantomjs --version) != '$PHANTOMJS_VERSION' ]; then rm -rf $PWD/travis_phantomjs; mkdir -p $PWD/travis_phantomjs; fi
+  - if [ $(phantomjs --version) != '$PHANTOMJS_VERSION' ]; then wget https://github.com/Medium/phantomjs/releases/download/v$PHANTOMJS_VERSION/phantomjs-$PHANTOMJS_VERSION-linux-x86_64.tar.bz2 -O $PWD/travis_phantomjs/phantomjs-$PHANTOMJS_VERSION-linux-x86_64.tar.bz2; fi
+  - if [ $(phantomjs --version) != '$PHANTOMJS_VERSION' ]; then tar -xvf $PWD/travis_phantomjs/phantomjs-$PHANTOMJS_VERSION-linux-x86_64.tar.bz2 -C $PWD/travis_phantomjs; fi
+  - phantomjs --version
 before_script:
   - npm install -g grunt-cli
 sudo: false
 cache:
   directories:
     - node_modules
+    - travis_phantomjs
 branches:
   only: [master]
+env:
+  - PHANTOMJS_VERSION=2.1.1

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -74,7 +74,6 @@ module.exports = function (grunt) {
           'node_modules/sinon/pkg/sinon.js',
           'node_modules/sinon-chai/lib/sinon-chai.js',
           'node_modules/chai-as-promised/lib/chai-as-promised.js',
-          'node_modules/es5-shim/es5-shim.js',
           'spec/spec_helper.js',
           'spec/**/*_spec.js'
         ],

--- a/lib/client.js
+++ b/lib/client.js
@@ -138,7 +138,7 @@ function postReplyWith(client, key, msg) {
   if (client._repliesPending[key]) { return; }
   msg.key = 'iframe.reply:' + key;
   client._repliesPending[key] = true;
-  when(client._messageHandlers[key]).then(
+  return when(client._messageHandlers[key]).then(
     rawPostMessage.bind(null, client, msg)
   ).catch(function(reason) {
     var rejectMessage;
@@ -197,7 +197,7 @@ function messageHandler(client, event) {
         msg = { appGuid: client._appGuid };
 
     if (data.needsReply) {
-      postReplyWith(clientRecipient, key, msg);
+      return postReplyWith(clientRecipient, key, msg);
     } else {
       triggerEvent(clientRecipient, key, data.message);
     }

--- a/lib/client.js
+++ b/lib/client.js
@@ -9,7 +9,7 @@ var PROMISE_TIMEOUT = 5000, // 5 seconds
     ids             = {};
 
 // @internal
-// #timeoutReject(name, params)
+// #timeoutReject(rejectionFn, name, params)
 //
 // Reject a request if required, given the rejection function, name (get, set or invoke)
 // and arguments to that request. Falls back to 5000 second timeout with few exceptions.

--- a/lib/client.js
+++ b/lib/client.js
@@ -141,14 +141,9 @@ function postReplyWith(client, key, msg) {
   return when(client._messageHandlers[key]).then(
     rawPostMessage.bind(null, client, msg)
   ).catch(function(reason) {
-    var rejectMessage;
     // if the handler throws an error we want to send back its message, but
     // Error objects don't pass through the postMessage boundary.
-    if (reason instanceof Error) {
-      rejectMessage = reason.message;
-    } else {
-      rejectMessage = reason;
-    }
+    var rejectMessage = reason instanceof Error ? reason.message : reason;
     msg.error = {
       msg: rejectMessage
     };

--- a/lib/client.js
+++ b/lib/client.js
@@ -141,8 +141,16 @@ function postReplyWith(client, key, msg) {
   when(client._messageHandlers[key]).then(
     rawPostMessage.bind(null, client, msg)
   ).catch(function(reason) {
+    var rejectMessage;
+    // if the handler throws an error we want to send back its message, but
+    // Error objects don't pass through the postMessage boundary.
+    if (reason instanceof Error) {
+      rejectMessage = reason.message;
+    } else {
+      rejectMessage = reason;
+    }
     msg.error = {
-      msg: reason
+      msg: rejectMessage
     };
     rawPostMessage(client, msg);
   }).then(function() {

--- a/lib/client.js
+++ b/lib/client.js
@@ -24,16 +24,23 @@ function timeoutReject(reject, name, paramsArray) {
       if(allWhitelisted) {
         return NaN; // timer IDs are numbers; embrace the JavaScript 😬
       } else {
-        var noneWhitelisted = matches.length === 0;
-        if (noneWhitelisted) {
-          return setTimeout(function() {
-            reject(new Error('Invocation request timeout'));
-          }, PROMISE_TIMEOUT);
+        var notAllWhitelisted = matches.length !== 0;
+        if (notAllWhitelisted) {
+          throw new Error('Illegal bulk call - `instances.create` must be called separately.');
         }
-        throw new Error('Illegal bulk call - `instances.create` must be called separately.');
+        return defaultTimer(reject);
       }
     }
+    default: {
+      return defaultTimer(reject);
+    }
   }
+}
+
+function defaultTimer(callback) {
+  return setTimeout(function() {
+    callback(new Error('Invocation request timeout'));
+  }, PROMISE_TIMEOUT);
 }
 
 function nextIdFor(name) {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "chai-as-promised": "^5.3.0",
-    "es5-shim": "^4.5.8",
     "grunt": "^1.0.1",
     "grunt-bump": "^0.7.0",
     "grunt-contrib-connect": "^1.0.1",
@@ -43,7 +42,6 @@
     "grunt-newer": "^1.1.2",
     "grunt-testem-mincer": "^0.5.18",
     "load-grunt-tasks": "^3.5.0",
-    "phantomjs-polyfill-find": "^0.0.1",
     "sinon": "^1.17.3",
     "sinon-chai": "^2.8.0",
     "time-grunt": "^1.3.0"

--- a/spec/client_spec.js
+++ b/spec/client_spec.js
@@ -11,6 +11,7 @@ describe('Client', function() {
 
   beforeEach(function() {
     sandbox.stub(window, 'addEventListener');
+    sandbox.stub(window, 'postMessage');
     source = { postMessage: sandbox.stub() };
     subject = new Client({ origin: origin, appGuid: appGuid, source: source });
   });

--- a/spec/client_spec.js
+++ b/spec/client_spec.js
@@ -1,7 +1,4 @@
-require('phantomjs-polyfill-find');
-
 describe('Client', function() {
-
   var Client  = require('client'),
       Promise = window.Promise || require('../vendor/native-promise-only'),
       sandbox = sinon.sandbox.create(),

--- a/spec/client_spec.js
+++ b/spec/client_spec.js
@@ -204,7 +204,6 @@ describe('Client', function() {
     });
 
     describe('#on', function() {
-
       it('registers a handler for a given event', function() {
         subject.on('foo', callback);
         expect(subject._messageHandlers.foo).to.exist;
@@ -226,7 +225,6 @@ describe('Client', function() {
         subject.on('foo', callback);
         expect(subject.postMessage).to.have.been.calledWithMatch('iframe.on:foo', { subscriberCount: 1 });
       });
-
     });
 
     describe('#off', function() {

--- a/testem.json
+++ b/testem.json
@@ -9,7 +9,6 @@
     "node_modules/sinon/pkg/sinon.js",
     "node_modules/sinon-chai/lib/sinon-chai.js",
     "node_modules/chai-as-promised/lib/chai-as-promised.js",
-    "node_modules/es5-shim/es5-shim.js",
     "spec/spec_helper.js",
     "spec/**/*_spec.js"
   ],


### PR DESCRIPTION
[postMessage](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) uses the [structured clone algo](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm) which does not like sending error objects.