### PR TITLE
Stop double nesting message

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -386,7 +386,7 @@ Client.prototype = {
   /// client.trigger('activation') // activating!
   /// ```
   trigger: function(name, data) {
-    this.postMessage('iframe.trigger:' + name, { message: data });
+    this.postMessage('iframe.trigger:' + name, data);
   },
 
   /// #### client.request(options)

--- a/spec/client_spec.js
+++ b/spec/client_spec.js
@@ -385,7 +385,7 @@ describe('Client', function() {
 
       it('posts a message so the framework can trigger the event on all registered clients', function() {
         subject.trigger('foo', data);
-        expect(subject.postMessage).to.have.been.calledWith('iframe.trigger:foo', { message: data });
+        expect(subject.postMessage).to.have.been.calledWith('iframe.trigger:foo', data);
       });
     });
 


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description
`postMessage` already wraps the second argument within `message` [here](https://github.com/zendesk/zendesk_app_framework_sdk/blob/master/lib/client.js#L272).

### Risks
* [low] `trigger` API may pass data incorrectly 