### PR TITLE
Export Promise

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -7,6 +7,9 @@ var PROMISE_TIMEOUT = 5000, // 5 seconds
     pendingPromises = {},
     ids             = {};
 
+// export Promise!
+window.Promise = Promise;
+
 // @internal
 // #timeoutReject(rejectionFn, name, params)
 //


### PR DESCRIPTION
/cc @zendesk/vegemite 

Currently we have a very nice polyfill in the SDK. But all apps that include this SDK, still don't have this polyfill available, which means all apps will need to include their own polyfill. This seems very strange to me, and it would be nice if we can export the polyfill to window, so apps automatically don't need to worry about Promise polyfill.

Export Promise to window so v2 apps don't need to include their own Promise polypill.

I have tested this, and it works great!