### PR TITLE
[APPS-3789] Setup event listeners for app tracking

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -215,6 +215,11 @@ function processResponse(path, result) {
   return result;
 }
 
+function setupTracking(client) {
+  window.addEventListener('click', function() {
+    client.invoke('track', { type: 'click' }) // Arturo filtering is being done on the ZAF side
+}
+
 var Client = function(options) {
   this._parent = options.parent;
   this._origin = options.origin || this._parent && this._parent._origin;
@@ -243,6 +248,7 @@ var Client = function(options) {
     return this; // shortcut handshake
   }
 
+  setupTracking(this)
   window.addEventListener('message', messageHandler.bind(null, this));
   this.postMessage('iframe.handshake', { version: version });
 };

--- a/lib/client.js
+++ b/lib/client.js
@@ -217,7 +217,7 @@ function processResponse(path, result) {
 
 function setupTracking(client) {
   window.addEventListener('click', function() {
-    client.invoke('track', { type: 'click' }) // Arturo filtering is being done on the ZAF side
+    client.invoke('track', { type: 'click' });
   }
 }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -218,6 +218,7 @@ function processResponse(path, result) {
 function setupTracking(client) {
   window.addEventListener('click', function() {
     client.invoke('track', { type: 'click' }) // Arturo filtering is being done on the ZAF side
+  }
 }
 
 var Client = function(options) {

--- a/spec/client_spec.js
+++ b/spec/client_spec.js
@@ -43,6 +43,10 @@ describe('Client', function() {
       expect(window.addEventListener).to.have.been.calledWith('message');
     });
 
+    it('adds a listener for the click event', function() {
+      expect(window.addEventListener).to.have.been.calledWith('click');
+    });
+
     it('defaults to the window.top source', function (){
       var client = new Client({ origin: origin, appGuid: appGuid });
       expect(client).to.have.property('_source', window.top);


### PR DESCRIPTION
Relies on the ZAF work here https://github.com/zendesk/zendesk_app_framework/pull/769 to send tracking blips whenever someone clicks in an app.

:stop_sign: This should not be deployed until the corresponding ZAF PR above is deployed (apps won't break, but there'll be a lot of console errors as the `invoke` call fails to find a handler for `track`. :stop_sign: 

https://zendesk.atlassian.net/browse/APPS-3789