### PR TITLE
optional queryString for init

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -24,8 +24,8 @@ var Client    = require('client'),
 ///   console.log('Hi ' + currentUser.name);
 /// });
 /// ```
-ZAFClient.init = function(callback) {
-  var queryParams = Utils.queryParameters(),
+ZAFClient.init = function(callback, queryString) {
+  var queryParams = Utils.queryParameters(queryString),
       hashParams = Utils.queryParameters(( document.location.hash || '' ).slice(1)),
       origin = queryParams.origin || hashParams.origin,
       app_guid = queryParams.app_guid || hashParams.app_guid,

--- a/lib/index.js
+++ b/lib/index.js
@@ -24,9 +24,10 @@ var Client    = require('client'),
 ///   console.log('Hi ' + currentUser.name);
 /// });
 /// ```
-ZAFClient.init = function(callback, queryString) {
-  var queryParams = Utils.queryParameters(queryString),
-      hashParams = Utils.queryParameters(( document.location.hash || '' ).slice(1)),
+ZAFClient.init = function(callback, loc) {
+  loc = loc || window.location;
+  var queryParams = Utils.queryParameters(loc.search),
+      hashParams = Utils.queryParameters(loc.hash),
       origin = queryParams.origin || hashParams.origin,
       app_guid = queryParams.app_guid || hashParams.app_guid,
       client;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -9,14 +9,17 @@ function decode(s) {
 }
 
 function queryParameters(queryString) {
+  queryString = queryString || '';
+
   var result = {},
       keyValuePairs,
       keyAndValue,
       key,
       value;
 
-  queryString = queryString ||
-    ( document.location.search || '' ).slice(1);
+  if (queryString.search(/\?|#/) === 0) {
+    queryString = queryString.slice(1);
+  }
 
   if (queryString.length === 0) { return result; }
 

--- a/spec/utils_spec.js
+++ b/spec/utils_spec.js
@@ -11,7 +11,11 @@ describe('Utils', function() {
         { queryStr: 'foo=0&bar=1&baz',      tests: { foo: '0', bar: '1', baz: '' } },
         { queryStr: 'foo=http://foo.com',   tests: { foo: 'http://foo.com' } },
         { queryStr: 'fooBar=A2&fooBar=A3',  tests: { fooBar: 'A3' } },
-        { queryStr: 'fooBar=A2&',           tests: { fooBar: 'A2' } }
+        { queryStr: 'fooBar=A2&',           tests: { fooBar: 'A2' } },
+        { queryStr: '?foo=0&bar=1&baz',      tests: { foo: '0', bar: '1', baz: '' } },
+        { queryStr: '?foo=http://foo.com',   tests: { foo: 'http://foo.com' } },
+        { queryStr: '#foo=0&bar=1&baz',      tests: { foo: '0', bar: '1', baz: '' } },
+        { queryStr: '#foo=http://foo.com',   tests: { foo: 'http://foo.com' } }
       ].forEach(function(testCase) {
         params = Utils.queryParameters(testCase.queryStr);
         Object.keys(testCase.tests).forEach(function(key) {


### PR DESCRIPTION
In jasmine we are trying to do fishy stuff to stub out the window.document.location.search, but instead we should be able to pass it to the init function so we can test this much easier!