### PR TITLE
[APPS-3789] Refactor tracking code to dodge bug in grunt-testem-mincer

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -5,7 +5,8 @@ var PROMISE_TIMEOUT = 5000, // 5 seconds
     Utils           = require('utils'),
     Promise         = window.Promise || require('../vendor/native-promise-only'),
     pendingPromises = {},
-    ids             = {};
+    ids             = {},
+    Tracking        = require('tracking');
 
 // export Promise!
 window.Promise = Promise;
@@ -218,12 +219,6 @@ function processResponse(path, result) {
   return result;
 }
 
-function setupTracking(client) {
-  window.addEventListener('click', function() {
-    client.invoke('track', { type: 'click' });
-  }
-}
-
 var Client = function(options) {
   this._parent = options.parent;
   this._origin = options.origin || this._parent && this._parent._origin;
@@ -252,7 +247,7 @@ var Client = function(options) {
     return this; // shortcut handshake
   }
 
-  setupTracking(this)
+  Tracking.setup(this);
   window.addEventListener('message', messageHandler.bind(null, this));
   this.postMessage('iframe.handshake', { version: version });
 };

--- a/lib/tracking.js
+++ b/lib/tracking.js
@@ -1,0 +1,7 @@
+function setup(client) {
+  window.addEventListener('click', function() {
+    client.invoke('track', { type: 'click' });
+  });
+}
+
+module.exports = { setup: setup };

--- a/spec/client_spec.js
+++ b/spec/client_spec.js
@@ -1,15 +1,17 @@
 describe('Client', function() {
-  var Client  = require('client'),
-      Promise = window.Promise || require('../vendor/native-promise-only'),
-      sandbox = sinon.sandbox.create(),
-      origin  = 'https://foo.zendesk.com',
-      appGuid = 'ABC123',
-      version = require('version'),
+  var Client   = require('client'),
+      Tracking = require('tracking'),
+      Promise  = window.Promise || require('../vendor/native-promise-only'),
+      sandbox  = sinon.sandbox.create(),
+      origin   = 'https://foo.zendesk.com',
+      appGuid  = 'ABC123',
+      version  = require('version'),
       subject,
       source,
       callback;
 
   beforeEach(function() {
+    sandbox.stub(Tracking, 'setup');
     sandbox.stub(window, 'addEventListener');
     sandbox.stub(window, 'postMessage');
     source = { postMessage: sandbox.stub() };
@@ -43,8 +45,8 @@ describe('Client', function() {
       expect(window.addEventListener).to.have.been.calledWith('message');
     });
 
-    it('adds a listener for the click event', function() {
-      expect(window.addEventListener).to.have.been.calledWith('click');
+    it('sets up tracking', function() {
+      expect(Tracking.setup).to.have.been.called;
     });
 
     it('defaults to the window.top source', function (){


### PR DESCRIPTION
`grunt-testem-mincer` is super out of date and relies on an old version of `testem`. This relies on an old version of `ws-pure`, which is forked from `ws` at the point where `ws` had a nasty bug (it would sometimes mysteriously throw out of range errors (https://github.com/websockets/ws/issues/778).

To avoid this bug I've just extracted all my code and stubbed it out in the test.

https://zendesk.atlassian.net/browse/APPS-3789

Risks:
none: just a test.