### PR TITLE
Add a whitelist of origins

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -219,6 +219,26 @@ function processResponse(path, result) {
   return result;
 }
 
+function isOriginValid(origin) {
+  var WHITELISTED_ORIGINS = [
+    /.*zendesk\.com.*/gi,
+    /.*zd-staging\.com.*/gi,
+    /.*zd-dev\.com.*/gi,
+    /.*zd-master\.com.*/gi,
+    /.*zendesk-staging\.com.*/gi,
+    /.*dashboard\.zopim\.com.*/gi,
+    /.*dashboard\.zopim\.org.*/gi
+  ];
+
+  for (var i = 0; i < WHITELISTED_ORIGINS.length; i++) {
+    if (WHITELISTED_ORIGINS[i].test(origin)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 var Client = function(options) {
   this._parent = options.parent;
   this._origin = options.origin || this._parent && this._parent._origin;
@@ -232,26 +252,8 @@ var Client = function(options) {
   this._context = options.context || null;
   this.ready = false;
 
-  var WHITELISTED_ORIGINS = [
-    /.*zendesk\.com.*/gi,
-    /.*zd-staging\.com.*/gi,
-    /.*zd-dev\.com.*/gi,
-    /.*zd-master\.com.*/gi,
-    /.*zendesk-staging\.com.*/gi,
-    /.*dashboard\.zopim\.com.*/gi,
-    /.*dashboard\.zopim\.org.*/gi
-  ];
-
-  var i;
-
-  for (i = 0; i < WHITELISTED_ORIGINS.length; i++) {
-    if (WHITELISTED_ORIGINS[i].test(this._origin)) {
-      break;
-    }
-  }
-
-  if (i == WHITELISTED_ORIGINS.length) {
-    throw 'Invalid domain';
+  if(!isOriginValid(this._origin)) {
+    throw new Error('Invalid domain');
   }
 
   this.on('app.registered', function(data) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -232,6 +232,28 @@ var Client = function(options) {
   this._context = options.context || null;
   this.ready = false;
 
+  var WHITELISTED_ORIGINS = [
+    /.*zendesk\.com.*/gi,
+    /.*zd-staging\.com.*/gi,
+    /.*zd-dev\.com.*/gi,
+    /.*zd-master\.com.*/gi,
+    /.*zendesk-staging\.com.*/gi,
+    /.*dashboard\.zopim\.com.*/gi,
+    /.*dashboard\.zopim\.org.*/gi
+  ];
+
+  var i;
+
+  for (i = 0; i < WHITELISTED_ORIGINS.length; i++) {
+    if (WHITELISTED_ORIGINS[i].test(this._origin)) {
+      break;
+    }
+  }
+
+  if (i == WHITELISTED_ORIGINS.length) {
+    throw 'Invalid domain';
+  }
+
   this.on('app.registered', function(data) {
     this.ready = true;
     this._metadata = data.metadata;

--- a/spec/client_spec.js
+++ b/spec/client_spec.js
@@ -36,6 +36,85 @@ describe('Client', function() {
     window.addEventListener.callArgWith(1, evt);
   }
 
+  describe('isDomainValid', function() {
+    it('Should instantiate client when domain is valid 1', function() {
+      var appSource = { postMessage: sandbox.stub() };
+      var validDomainClient = new Client({
+        origin: 'https://sub1.zendesk.com',
+        appGuid: 'appGuid',
+        source: appSource
+      });
+
+      expect(validDomainClient).to.exist;
+    });
+
+    it('Should instantiate client when domain is valid 2', function() {
+      var appSource = { postMessage: sandbox.stub() };
+      var validDomainClient = new Client({
+        origin: 'https://sub1.zd-staging.com',
+        appGuid: 'appGuid',
+        source: appSource
+      });
+
+      expect(validDomainClient).to.exist;
+    });
+
+    it('Should instantiate client when domain is valid 3', function() {
+      var appSource = { postMessage: sandbox.stub() };
+      var validDomainClient = new Client({
+        origin: 'https://sub1.zendesk-staging.com',
+        appGuid: 'appGuid',
+        source: appSource
+      });
+
+      expect(validDomainClient).to.exist;
+    });
+
+    it('Should instantiate client when domain is valid 4', function() {
+      var appSource = { postMessage: sandbox.stub() };
+      var validDomainClient = new Client({
+        origin: 'https://sub1.zd-master.com',
+        appGuid: 'appGuid',
+        source: appSource
+      });
+
+      expect(validDomainClient).to.exist;
+    });
+
+    it('Should instantiate client when domain is valid 5', function() {
+      var appSource = { postMessage: sandbox.stub() };
+      var validDomainClient = new Client({
+        origin: 'https://dashboard.zopim.com',
+        appGuid: 'appGuid',
+        source: appSource
+      });
+
+      expect(validDomainClient).to.exist;
+    });
+
+    it('Should instantiate client when domain is valid 6', function() {
+      var appSource = { postMessage: sandbox.stub() };
+      var validDomainClient = new Client({
+        origin: 'https://dashboard.zopim.org',
+        appGuid: 'appGuid',
+        source: appSource
+      });
+
+      expect(validDomainClient).to.exist;
+    });
+
+    it('Should throw when domain is invalid', function() {
+      var appSource = { postMessage: sandbox.stub() };
+      expect(function() {
+        new Client({
+          origin: 'https://invalid-domain.com',
+          appGuid: 'appGuid',
+          source: appSource
+        });
+      }).to.throw(Error);
+    });
+  });
+
   describe('initialisation', function() {
     it('can be instantiated', function() {
       expect(subject).to.exist;

--- a/spec/client_spec.js
+++ b/spec/client_spec.js
@@ -36,65 +36,65 @@ describe('Client', function() {
     window.addEventListener.callArgWith(1, evt);
   }
 
-  describe('isDomainValid', function() {
+  describe('isOriginValid', function() {
     it('Should instantiate client for support production domain(subdomain.zendesk.com)', function() {
-      var validDomainClient = new Client({
+      var validOriginClient = new Client({
         origin: 'https://sub1.zendesk.com',
         appGuid: 'appGuid',
         source: source
       });
 
-      expect(validDomainClient).to.exist;
+      expect(validOriginClient).to.exist;
     });
 
     it('Should instantiate client for support old staging domain(subdomain.zd-staging.com)', function() {
-      var validDomainClient = new Client({
+      var validOriginClient = new Client({
         origin: 'https://sub1.zd-staging.com',
         appGuid: 'appGuid',
         source: source
       });
 
-      expect(validDomainClient).to.exist;
+      expect(validOriginClient).to.exist;
     });
 
     it('Should instantiate client for support new staging domain(subdomain.zendesk-staging.com)', function() {
-      var validDomainClient = new Client({
+      var validOriginClient = new Client({
         origin: 'https://sub1.zendesk-staging.com',
         appGuid: 'appGuid',
         source: source
       });
 
-      expect(validDomainClient).to.exist;
+      expect(validOriginClient).to.exist;
     });
 
     it('Should instantiate client for support master stage domain(subdomain.zd-master.com)', function() {
-      var validDomainClient = new Client({
+      var validOriginClient = new Client({
         origin: 'https://sub1.zd-master.com',
         appGuid: 'appGuid',
         source: source
       });
 
-      expect(validDomainClient).to.exist;
+      expect(validOriginClient).to.exist;
     });
 
     it('Should instantiate client for chat production domain(dashboard.zopim.com)', function() {
-      var validDomainClient = new Client({
+      var validOriginClient = new Client({
         origin: 'https://dashboard.zopim.com',
         appGuid: 'appGuid',
         source: source
       });
 
-      expect(validDomainClient).to.exist;
+      expect(validOriginClient).to.exist;
     });
 
     it('Should instantiate client for chat staging domain(dashboard.zopim.org)', function() {
-      var validDomainClient = new Client({
+      var validOriginClient = new Client({
         origin: 'https://dashboard.zopim.org',
         appGuid: 'appGuid',
         source: source
       });
 
-      expect(validDomainClient).to.exist;
+      expect(validOriginClient).to.exist;
     });
 
     it('Should throw when domain is invalid', function() {

--- a/spec/client_spec.js
+++ b/spec/client_spec.js
@@ -37,79 +37,72 @@ describe('Client', function() {
   }
 
   describe('isDomainValid', function() {
-    it('Should instantiate client when domain is valid 1', function() {
-      var appSource = { postMessage: sandbox.stub() };
+    it('Should instantiate client for support production domain(subdomain.zendesk.com)', function() {
       var validDomainClient = new Client({
         origin: 'https://sub1.zendesk.com',
         appGuid: 'appGuid',
-        source: appSource
+        source: source
       });
 
       expect(validDomainClient).to.exist;
     });
 
-    it('Should instantiate client when domain is valid 2', function() {
-      var appSource = { postMessage: sandbox.stub() };
+    it('Should instantiate client for support old staging domain(subdomain.zd-staging.com)', function() {
       var validDomainClient = new Client({
         origin: 'https://sub1.zd-staging.com',
         appGuid: 'appGuid',
-        source: appSource
+        source: source
       });
 
       expect(validDomainClient).to.exist;
     });
 
-    it('Should instantiate client when domain is valid 3', function() {
-      var appSource = { postMessage: sandbox.stub() };
+    it('Should instantiate client for support new staging domain(subdomain.zendesk-staging.com)', function() {
       var validDomainClient = new Client({
         origin: 'https://sub1.zendesk-staging.com',
         appGuid: 'appGuid',
-        source: appSource
+        source: source
       });
 
       expect(validDomainClient).to.exist;
     });
 
-    it('Should instantiate client when domain is valid 4', function() {
-      var appSource = { postMessage: sandbox.stub() };
+    it('Should instantiate client for support master stage domain(subdomain.zd-master.com)', function() {
       var validDomainClient = new Client({
         origin: 'https://sub1.zd-master.com',
         appGuid: 'appGuid',
-        source: appSource
+        source: source
       });
 
       expect(validDomainClient).to.exist;
     });
 
-    it('Should instantiate client when domain is valid 5', function() {
-      var appSource = { postMessage: sandbox.stub() };
+    it('Should instantiate client for chat production domain(dashboard.zopim.com)', function() {
       var validDomainClient = new Client({
         origin: 'https://dashboard.zopim.com',
         appGuid: 'appGuid',
-        source: appSource
+        source: source
       });
 
       expect(validDomainClient).to.exist;
     });
 
-    it('Should instantiate client when domain is valid 6', function() {
-      var appSource = { postMessage: sandbox.stub() };
+    it('Should instantiate client for chat staging domain(dashboard.zopim.org)', function() {
       var validDomainClient = new Client({
         origin: 'https://dashboard.zopim.org',
         appGuid: 'appGuid',
-        source: appSource
+        source: source
       });
 
       expect(validDomainClient).to.exist;
     });
 
     it('Should throw when domain is invalid', function() {
-      var appSource = { postMessage: sandbox.stub() };
       expect(function() {
         new Client({
           origin: 'https://invalid-domain.com',
           appGuid: 'appGuid',
-          source: appSource
+          source: source
         });
       }).to.throw(Error);
     });

--- a/spec/index_spec.js
+++ b/spec/index_spec.js
@@ -16,7 +16,7 @@ describe('ZAFClient', function() {
     describe('given origin and app_guid exist', function() {
       beforeEach(function() {
         Utils.queryParameters.returns({
-          origin: document.location,
+          origin: 'https://subdomain.zendesk.com',
           app_guid: 'A2'
         });
       });


### PR DESCRIPTION
Any website can include zendesk_app_framework, embed one of our iframed app, and be able to sniff the events and data. This PR is adding a whitelist of domains to prevent this.

Reported Issue: https://support.zendesk.com/agent/tickets/3371584

@zendesk/vegemite 

Limitations: Since this is a front-end only fix, anyone can easily bypass this, we should think about adding nginx rules on the app assets to not be allowed to be iframed on any other domains.