### PR TITLE
Throw when domain is invalid

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -254,8 +254,8 @@ var Client = function(options) {
   this._context = options.context || null;
   this.ready = false;
 
-  if(!isOriginValid(this._origin)) {
-    console && console.error('Invalid domain: ' + this._origin);
+  if (!isOriginValid(this._origin)) {
+    throw new Error('Invalid domain ' + this._origin);
   }
 
   this.on('app.registered', function(data) {

--- a/spec/client_spec.js
+++ b/spec/client_spec.js
@@ -85,12 +85,13 @@ describe('Client', function() {
       ];
 
       invalidDomains.forEach(function(domain) {
-        new Client({
-          origin: domain,
-          appGuid: 'appGuid',
-          source: source
-        });
-        expect(console.error).to.have.been.calledWith('Invalid domain: ' + domain);
+        expect(function() {
+          new Client({
+            origin: domain,
+            appGuid: 'appGuid',
+            source: source
+          });
+        }).to.throw(Error);
       });
     });
   });


### PR DESCRIPTION
I verified that our regex pattern for validating domains matches with the one's used by the [JIRA app](https://github.com/zendesk/jig/blob/master/config/initializers/charcoal.rb#L2).

Since, the jira app has been out in production for a long time and being used by thousands of customers, I think we should be confident and throw an error on any domain than does not match our regex pattern.

@zendesk/vegemite 