### PR TITLE
Instead of throw, send to DD

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -254,8 +254,15 @@ var Client = function(options) {
   this._context = options.context || null;
   this.ready = false;
 
-  if (!isOriginValid(this._origin)) {
-    throw new Error('Invalid domain ' + this._origin);
+  if (this._origin && isOriginValid(this._origin)) {
+    var origin_hostname = new URL(this._origin).hostname;
+    this.postMessage('tracker', {
+      event_name: 'invalid_domain',
+      event_type: 'increment',
+      data: 1, 
+      tags: ["origin:" + origin_hostname]
+    });
+    // throw new Error('Invalid domain ' + this._origin);
   }
 
   this.on('app.registered', function(data) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -220,21 +220,23 @@ function processResponse(path, result) {
 }
 
 function isOriginValid(origin) {
-  var WHITELISTED_ORIGINS = [
-    /^https?:\/\/127.0.0.1(:\d+)?$/,
-    /^https?:\/\/localhost(:\d+)?$/,
-    /^https:\/\/.+\.zendesk\.com$/,
-    /^https:\/\/.+\.zd-staging\.com$/,
-    /^https:\/\/.+\.zd-dev\.com$/,
-    /^https:\/\/.+\.zd-master\.com$/,
-    /^https:\/\/.+\.zendesk-staging\.com$/,
-    /^https?:\/\/.+\.zopim\.com(:\d+)?$/,
-    /^https:\/\/dashboard\.zopim\.org$/
-  ];
+  if (origin) {
+    var WHITELISTED_ORIGINS = [
+      /^https?:\/\/127.0.0.1(:\d+)?$/,
+      /^https?:\/\/localhost(:\d+)?$/,
+      /^https:\/\/.+\.zendesk\.com$/,
+      /^https:\/\/.+\.zd-staging\.com$/,
+      /^https:\/\/.+\.zd-dev\.com$/,
+      /^https:\/\/.+\.zd-master\.com$/,
+      /^https:\/\/.+\.zendesk-staging\.com$/,
+      /^https?:\/\/.+\.zopim\.com(:\d+)?$/,
+      /^https:\/\/dashboard\.zopim\.org$/
+    ];
 
-  for (var i = 0; i < WHITELISTED_ORIGINS.length; i++) {
-    if (WHITELISTED_ORIGINS[i].test(origin)) {
-      return true;
+    for (var i = 0; i < WHITELISTED_ORIGINS.length; i++) {
+      if (WHITELISTED_ORIGINS[i].test(origin)) {
+        return true;
+      }
     }
   }
 
@@ -254,15 +256,14 @@ var Client = function(options) {
   this._context = options.context || null;
   this.ready = false;
 
-  if (this._origin && isOriginValid(this._origin)) {
+  if (!isOriginValid(this._origin)) {
     var origin_hostname = new URL(this._origin).hostname;
-    this.postMessage('tracker', {
-      event_name: 'invalid_domain',
+    this.postMessage('__track__', {
+      event_name: 'invalid_sdk_origin',
       event_type: 'increment',
-      data: 1, 
+      data: 1,
       tags: ["origin:" + origin_hostname]
     });
-    // throw new Error('Invalid domain ' + this._origin);
   }
 
   this.on('app.registered', function(data) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -264,6 +264,8 @@ var Client = function(options) {
       data: 1,
       tags: ["origin:" + origin_hostname]
     });
+    
+    console && console.error('Invalid domain: ' + this._origin);
   }
 
   this.on('app.registered', function(data) {

--- a/spec/client_spec.js
+++ b/spec/client_spec.js
@@ -85,13 +85,12 @@ describe('Client', function() {
       ];
 
       invalidDomains.forEach(function(domain) {
-        expect(function() {
-          new Client({
-            origin: domain,
-            appGuid: 'appGuid',
-            source: source
-          });
-        }).to.throw(Error);
+        new Client({
+          origin: domain,
+          appGuid: 'appGuid',
+          source: source
+        });
+        expect(console.error).to.have.been.calledWith('Invalid domain: ' + domain);
       });
     });
   });


### PR DESCRIPTION
Send the invalid domain error to Datadog instead of throwing. We can monitor this for a few days before we release the versions which throws, as throwing an error here(if done wrong) can we very high risk and can break a lot of apps.

Requires ZAF PR: https://github.com/zendesk/zendesk_app_framework/pull/788

@zendesk/vegemite 