### PR TITLE
Send data to DD on timeout reject

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -17,7 +17,7 @@ window.Promise = Promise;
 // Reject a request if required, given the rejection function, name (get, set or invoke)
 // and arguments to that request. Falls back to 5000 second timeout with few exceptions.
 //
-function timeoutReject(reject, name, paramsArray) {
+function timeoutReject(reject, name, client, paramsArray) {
   switch(name) {
     case 'invoke': {
       var matches = paramsArray.filter(function(action) {
@@ -31,17 +31,23 @@ function timeoutReject(reject, name, paramsArray) {
         if (notAllWhitelisted) {
           throw new Error('Illegal bulk call - `instances.create` must be called separately.');
         }
-        return defaultTimer(reject);
+        return defaultTimer(client, reject);
       }
     }
     default: {
-      return defaultTimer(reject);
+      return defaultTimer(client, reject);
     }
   }
 }
 
-function defaultTimer(callback) {
+function defaultTimer(client, callback) {
   return setTimeout(function() {
+    client.postMessage('__track__', {
+      event_name: 'sdk_request_timeout',
+      event_type: 'increment',
+      data: 1
+    });
+
     callback(new Error('Invocation request timeout'));
   }, PROMISE_TIMEOUT);
 }
@@ -84,7 +90,7 @@ function wrappedPostMessage(name, params) {
 
   var promise = new Promise(function(resolve, reject) {
     // Time out the promise to ensure it will be garbage collected if nobody responds
-    timeoutId = timeoutReject(reject, name, Array.isArray(params) ? params : Object.keys(params));
+    timeoutId = timeoutReject(reject, name, this, Array.isArray(params) ? params : Object.keys(params));
 
     pendingPromises[id] = { resolve: resolve, reject: reject };
 
@@ -264,7 +270,7 @@ var Client = function(options) {
       data: 1,
       tags: ["origin:" + origin_hostname]
     });
-    
+
     console && console.error('Invalid domain: ' + this._origin);
   }
 


### PR DESCRIPTION
@zendesk/vegemite 

Send an event to DD when a ZAF request times out.

### Risk
LOW. Just adding a new metric to send to DD.