### PR TITLE
Empty commit message for consistency with legacy Grunt bump task

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,9 +51,9 @@
     "webpack-dev-server": "^3.1.5"
   },
   "scripts": {
-    "bump": "bump --patch --tag --commit",
-    "bump:minor": "bump --minor --tag --commit",
-    "bump:major": "bump --major --tag --commit",
+    "bump": "bump --patch --tag --commit ' '",
+    "bump:minor": "bump --minor --tag --commit ' '",
+    "bump:major": "bump --major --tag --commit ' '",
     "test": "karma start --single-run",
     "server": "webpack-dev-server",
     "build:dev": "webpack",


### PR DESCRIPTION
✌️

/cc @zendesk/vegemite

### Description
Amends the `npm run-script bump` task added in https://github.com/zendesk/zendesk_app_framework_sdk/pull/78 to stay consistent with the legacy `grunt bump` task.

### Risks
None - only updates the commit message.