### PR TITLE
Increase promise timeout to 10 seconds

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1,5 +1,5 @@
-var PROMISE_TIMEOUT = 5000
-// 5 seconds
+var PROMISE_TIMEOUT = 10000
+// 10 seconds
 var PROMISE_DONT_TIMEOUT = ['instances.create']
 var ZAF_EVENT = /^zaf\./
 var version = require('version')

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,5 +1,5 @@
 var PROMISE_TIMEOUT = 10000
-// 10 seconds
+// 10 seconds, see ZD#4058685
 var PROMISE_DONT_TIMEOUT = ['instances.create']
 var ZAF_EVENT = /^zaf\./
 var version = require('version')
@@ -16,7 +16,7 @@ window.Promise = Promise
 // #timeoutReject(rejectionFn, name, params)
 //
 // Reject a request if required, given the rejection function, name (get, set or invoke)
-// and arguments to that request. Falls back to 5000 second timeout with few exceptions.
+// and arguments to that request. Falls back to 10000 second timeout with few exceptions.
 //
 function timeoutReject (reject, name, client, paramsArray) {
   switch (name) {

--- a/spec/client_spec.js
+++ b/spec/client_spec.js
@@ -5,6 +5,7 @@ describe('Client', function () {
   var Tracking = require('../lib/tracking')
   var Tracker = Tracking.Tracker
   var Promise = window.Promise || require('native-promise-only')
+  var PROMISE_TIMEOUT = 10000
   var sandbox = sinon.sandbox.create()
   var origin = 'https://foo.zendesk.com'
   var appGuid = 'ABC123'
@@ -571,10 +572,10 @@ describe('Client', function () {
         }).to.throw(Error)
       })
 
-      it('rejects the promise after 5 seconds', function (done) {
+      it('rejects the promise after 10 seconds', function (done) {
         var clock = sinon.useFakeTimers()
         promise = subject.get('ticket.subject')
-        clock.tick(5000)
+        clock.tick(PROMISE_TIMEOUT)
         clock.restore()
         expect(promise).to.be.rejectedWith(Error, 'Invocation request timeout').and.notify(done)
       })
@@ -659,10 +660,10 @@ describe('Client', function () {
         })
       })
 
-      it('rejects the promise after 5 seconds', function (done) {
+      it('rejects the promise after 10 seconds', function (done) {
         var clock = sinon.useFakeTimers()
         promise = subject.set('ticket.subject', 'test')
-        clock.tick(5000)
+        clock.tick(PROMISE_TIMEOUT)
         clock.restore()
         expect(promise).to.be.rejectedWith(Error, 'Invocation request timeout').and.notify(done)
       })
@@ -718,18 +719,18 @@ describe('Client', function () {
         }).to.throw(Error, 'Invoke supports string arguments or an object with array of strings.')
       })
 
-      it('rejects the promise after 5 seconds', function (done) {
+      it('rejects the promise after 10 seconds', function (done) {
         var clock = sinon.useFakeTimers()
         promise = subject.invoke('ticket.subject', 'test')
-        clock.tick(5000)
+        clock.tick(PROMISE_TIMEOUT)
         clock.restore()
         expect(promise).to.be.rejectedWith(Error, 'Invocation request timeout').and.notify(done)
       })
 
-      it('doesnt reject whitelisted promises after 5 seconds', function (done) {
+      it('doesnt reject whitelisted promises after 10 seconds', function (done) {
         var clock = sinon.useFakeTimers()
         promise = subject.invoke('instances.create')
-        clock.tick(10000)
+        clock.tick(15000)
         clock.restore()
         expect(promise).to.eventually.become({ errors: {}, 'instances.create': { url: 'http://a.b' } }).and.notify(done)
         window.addEventListener.callArgWith(1, {


### PR DESCRIPTION
@zendesk/vegemite

Increase promise timeout to 10 seconds to allow more time for requests to resolve. It seems especially during initialisation 5 seconds may not be enough for requests to complete when many apps are loading at the same time.

### References
ZD#4058685

### Risks
- [low]  In case there's a legitimate reason for `postMessage` to never resolve it will take longer for the app to be able to handle the error.