### PR TITLE
Fixed output of webpack

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,6 +20,7 @@ const commonConfig = {
 
   output: {
     library: 'ZAFClient',
+    libraryExport: 'default',
     filename: '[name].js',
     path: path.resolve(__dirname, 'build')
   },


### PR DESCRIPTION
`ZAFClient` should have a `init` function, not a `default` property that has a `init` function.