### PR TITLE
Maintaining backwards compatibility for client.requests without payloadV2

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -483,13 +483,9 @@ export default class Client {
         options = { url: options }
       }
 
-      this.on(requestKey + '.done', (evt) => {
-        resolve.apply(this, evt.responseArgs)
-      })
+      this.on(requestKey + '.done', (evt) => resolve(evt.responseArgs[0]))
 
-      this.on(requestKey + '.fail', (evt) => {
-        reject.apply(this, evt.responseArgs)
-      })
+      this.on(requestKey + '.fail', (evt) => reject(evt.responseArgs[0]))
 
       this.postMessage(requestKey, options)
     })


### PR DESCRIPTION
✌️ @zendesk/vegemite 

## Description
This is a part of "allowing developers to opt in to the new request payload".

There are currently two ways to use `client.request(url)`. The first is to pass in an entire url as a string. The second is by passing in an object with key url (i.e. `client.request({url: "www.foobar.com"})`).

In the future, we want to let developers opt in to the new request payload by going `zafClient.request({url:'https://wikipedia.org', payloadV2: true})`, but we still want to maintain the backwards compatibility for how they currently work.

## Discovery
Looking into the request method in _zendesk_app_framework_sdk/lib/client.js_, let's find out what is in `evt.responseArgs` using debugger
<img width="358" alt="screen shot 2018-12-28 at 1 38 45 pm" src="https://user-images.githubusercontent.com/17760485/50502081-9d3c3000-0ab0-11e9-8816-e60e49bde8d7.png">

### When ".done" (_zafClient.request('https://wikipedia.org')_)

<img width="557" alt="screen shot 2018-12-28 at 1 48 19 pm" src="https://user-images.githubusercontent.com/17760485/50502422-3409ec00-0ab3-11e9-991e-ea4ffae365e9.png">

The information that is needed by the developers is only in the first element of the array (response body). Everything else is noise.


### When ".fail"  (_zafClient.request('https://wikipediqwea.org')_) - with invalid url

<img width="589" alt="screen shot 2018-12-31 at 10 35 20 am" src="https://user-images.githubusercontent.com/17760485/50552465-ede99e00-0ce7-11e9-965e-d83d2d7b727d.png">

The information that is needed by the developers is ALSO in the first element of the array.

## Approach
1. `resolve` and `reject` of Promise now uses fat arrow functions, with `event[responseArgs]` as an argument.   <details><summary>fat arrow functions!</summary><img width="470" alt="screen shot 2018-12-28 at 1 36 56 pm" src="https://user-images.githubusercontent.com/17760485/50500529-0b2f2a00-0aa6-11e9-8145-359722ce4c0a.png"></details>

2.  In **Discovery**, we learnt that we can specify which element of the `responseArgs` array (i.e. `event[responseArgs][0]` or `event.response[0]`) to return and eliminate unnecessary noise.

## References
1. [Jira](https://zendesk.atlassian.net/browse/AF-800)
2. ZAF changes - TBU
3. [.apply for context](https://medium.com/@owenyangg/javascript-call-apply-and-bind-explained-to-a-total-noob-63f146684564)

## Risks
- [low] - maintaining backward compatibility for `client.request(url)`
