### PR TITLE
[AF-1476] Add API tags to request timeout tracking

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -16,12 +16,13 @@ const ids = {}
 window.Promise = Promise
 
 // @internal
-// #timeoutReject(rejectionFn, name, params)
+// #timeoutReject(rejectionFn, name, client, params)
 //
 // Reject a request if required, given the rejection function, name (get, set or invoke)
 // and arguments to that request. Falls back to 10000 second timeout with few exceptions.
 //
 function timeoutReject (reject, name, client, paramsArray) {
+  const actions = paramsArray.map(action => `${name}-${action}`)
   switch (name) {
     case 'invoke': {
       const matches = paramsArray.filter((action) => {
@@ -35,21 +36,23 @@ function timeoutReject (reject, name, client, paramsArray) {
         if (notAllWhitelisted) {
           throw new Error('Illegal bulk call - `instances.create` must be called separately.')
         }
-        return defaultTimer(client, reject)
+        return defaultTimer(client, actions, reject)
       }
     }
     default: {
-      return defaultTimer(client, reject)
+      return defaultTimer(client, actions, reject)
     }
   }
 }
 
-function defaultTimer (client, callback) {
+function defaultTimer (client, actions, callback) {
+  const actionsTags = actions.map(action => `action: ${action}`)
   return setTimeout(() => {
     client.postMessage('__track__', {
       event_name: 'sdk_request_timeout',
       event_type: 'increment',
-      data: 1
+      data: 1,
+      tags: actionsTags
     })
 
     callback(new Error('Invocation request timeout'))


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description
Adds tags to the `sdk_request_timeout` event tracking to capture which APIs timed out. 

Related to https://github.com/zendesk/zendesk_app_framework/pull/823.

### References
* JIRA: https://zendesk.atlassian.net/browse/AF-1476

### Risks
* Low - Datadog tracking for `sdk_request_timeout` fails because of errors in tag strings.