### PR TITLE
[AF-1514] Constrain tags sent to Datadog for SDK request timeout events

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -45,8 +45,17 @@ function timeoutReject (reject, name, client, paramsArray) {
   }
 }
 
+export function stripActionArgs(action) {
+  // Capture:
+  // 1. single or multiple comma-delimited arguments following an initial colon, and
+  // 2. non-whitelisted words following a period (i.e. file extensions in the case of assetURL calls)
+  const ACTION_ARGS = /\:\w+(,?\w+)*((\.(show|hide|enable|disable))|(\.\w*))?/g;
+  // Return :arg.field_modifier, where field modifier is one of 'show', 'hide', 'enable' or 'disable'
+  return action.replace(ACTION_ARGS, ':arg$3')
+}
+
 function defaultTimer (client, actions, callback) {
-  const actionsTags = actions.map(action => `action: ${action}`)
+  const actionsTags = actions.map(action => `action:${stripActionArgs(action)}`)
   return setTimeout(() => {
     client.postMessage('__track__', {
       event_name: 'sdk_request_timeout',

--- a/lib/client.js
+++ b/lib/client.js
@@ -48,9 +48,9 @@ function timeoutReject (reject, name, client, paramsArray) {
 export function stripActionArgs (action) {
   // Capture:
   // 1. single or multiple comma-delimited arguments following an initial colon, and
-  // 2. non-whitelisted words following a period (i.e. file extensions in the case of assetURL calls)
-  const ACTION_ARGS = /:\w+(,?\w+)*((\.(show|hide|enable|disable))|(\.\w*))?/g
-  // Return :arg.field_modifier, where field modifier is one of 'show', 'hide', 'enable' or 'disable'
+  // 2. non-whitelisted, unescaped words following a period (i.e. file extensions in the case of assetURL calls)
+  const ACTION_ARGS = /:\w+(,?\w+)*((\.(show|hide|enable|disable))|(\\?\.\w*))?/g
+  // Return :arg.field_modifier, where field modifier is (optionally) one of 'show', 'hide', 'enable' or 'disable'
   return action.replace(ACTION_ARGS, ':arg$3')
 }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -45,11 +45,11 @@ function timeoutReject (reject, name, client, paramsArray) {
   }
 }
 
-export function stripActionArgs(action) {
+export function stripActionArgs (action) {
   // Capture:
   // 1. single or multiple comma-delimited arguments following an initial colon, and
   // 2. non-whitelisted words following a period (i.e. file extensions in the case of assetURL calls)
-  const ACTION_ARGS = /\:\w+(,?\w+)*((\.(show|hide|enable|disable))|(\.\w*))?/g;
+  const ACTION_ARGS = /:\w+(,?\w+)*((\.(show|hide|enable|disable))|(\.\w*))?/g
   // Return :arg.field_modifier, where field modifier is one of 'show', 'hide', 'enable' or 'disable'
   return action.replace(ACTION_ARGS, ':arg$3')
 }

--- a/spec/client_spec.js
+++ b/spec/client_spec.js
@@ -1,11 +1,38 @@
 /* eslint-env mocha */
 /* global expect Promise */
-import Client from '../lib/client'
+import Client, { stripActionArgs } from '../lib/client'
 import Tracker from '../lib/tracker'
 import version from 'version'
 import sinon from 'sinon'
 
 const PROMISE_TIMEOUT = 10000
+
+describe('#stripActionArgs', () => {
+  it('should replace a single argument following a colon', () => {
+    const action = 'get-ticket.customfield:custom_field_24378895';
+    expect(stripActionArgs(action)).to.equal('get-ticket.customfield:arg')
+  });
+
+  it('should replace multiple comma delimited arguments following a colon', () => {
+    const action = 'get-currentuser.customfield:partner,manager';
+    expect(stripActionArgs(action)).to.equal('get-currentuser.customfield:arg')
+  });
+
+  it('should retain trailing field modifiers', () => {
+    const action = 'invoke-ticketfields:custom_field_24049313.hide';
+    expect(stripActionArgs(action)).to.equal('invoke-ticketfields:arg.hide');
+  });
+
+  it('should replace arguments containing file extensions', () => {
+    const action = 'get-asseturl:logo.png';
+    expect(stripActionArgs(action)).to.equal('get-asseturl:arg')
+  });
+
+  it('should leave actions not containing arguments unchanged', () => {
+    const action = 'get-comment.attachments';
+    expect(stripActionArgs(action)).to.equal(action);
+  });
+});
 
 describe('Client', () => {
   const sandbox = sinon.createSandbox()

--- a/spec/client_spec.js
+++ b/spec/client_spec.js
@@ -23,8 +23,8 @@ describe('#stripActionArgs', () => {
     expect(stripActionArgs(action)).to.equal('invoke-ticketfields:arg.hide')
   })
 
-  it('should replace arguments containing file extensions', () => {
-    const action = 'get-asseturl:logo.png'
+  it('should replace arguments containing escaped file extensions', () => {
+    const action = 'get-asseturl:logo\\.png'
     expect(stripActionArgs(action)).to.equal('get-asseturl:arg')
   })
 

--- a/spec/client_spec.js
+++ b/spec/client_spec.js
@@ -9,30 +9,30 @@ const PROMISE_TIMEOUT = 10000
 
 describe('#stripActionArgs', () => {
   it('should replace a single argument following a colon', () => {
-    const action = 'get-ticket.customfield:custom_field_24378895';
+    const action = 'get-ticket.customfield:custom_field_24378895'
     expect(stripActionArgs(action)).to.equal('get-ticket.customfield:arg')
-  });
+  })
 
   it('should replace multiple comma delimited arguments following a colon', () => {
-    const action = 'get-currentuser.customfield:partner,manager';
+    const action = 'get-currentuser.customfield:partner,manager'
     expect(stripActionArgs(action)).to.equal('get-currentuser.customfield:arg')
-  });
+  })
 
   it('should retain trailing field modifiers', () => {
-    const action = 'invoke-ticketfields:custom_field_24049313.hide';
-    expect(stripActionArgs(action)).to.equal('invoke-ticketfields:arg.hide');
-  });
+    const action = 'invoke-ticketfields:custom_field_24049313.hide'
+    expect(stripActionArgs(action)).to.equal('invoke-ticketfields:arg.hide')
+  })
 
   it('should replace arguments containing file extensions', () => {
-    const action = 'get-asseturl:logo.png';
+    const action = 'get-asseturl:logo.png'
     expect(stripActionArgs(action)).to.equal('get-asseturl:arg')
-  });
+  })
 
   it('should leave actions not containing arguments unchanged', () => {
-    const action = 'get-comment.attachments';
-    expect(stripActionArgs(action)).to.equal(action);
-  });
-});
+    const action = 'get-comment.attachments'
+    expect(stripActionArgs(action)).to.equal(action)
+  })
+})
 
 describe('Client', () => {
   const sandbox = sinon.createSandbox()


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description
Removes arguments from the action tags captured for `sdk_request_timeout` events, reducing the likelihood of unbounded custom metrics being sent to Datadog.

See: https://zendesk.slack.com/archives/C1230V1CG/p1550706092011000?thread_ts=1550706075.010600&cid=C1230V1CG.

### References
* JIRA: https://zendesk.atlassian.net/browse/AF-1514

### Risks
* Low - Datadog tracking for `sdk_request_timeout` fails because of errors in tag strings.