### PR TITLE
[AF-1528] Add instrumentation to measure time for SDK request timeouts

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -7,7 +7,7 @@ import NativePromise from 'native-promise-only'
 const Promise = window.Promise || NativePromise
 const PROMISE_TIMEOUT = 10000
 // 10 seconds, see ZD#4058685
-const PROMISE_DONT_TIMEOUT = ['instances.create']
+const NO_TIMEOUT_ACTIONS = ['instances.create']
 const ZAF_EVENT = /^zaf\./
 const pendingPromises = {}
 const ids = {}
@@ -26,7 +26,7 @@ function timeoutReject (reject, name, client, paramsArray) {
   switch (name) {
     case 'invoke': {
       const matches = paramsArray.filter((action) => {
-        return PROMISE_DONT_TIMEOUT.indexOf(action) !== -1
+        return NO_TIMEOUT_ACTIONS.indexOf(action) !== -1
       })
       const allWhitelisted = matches.length === paramsArray.length
       if (allWhitelisted) {
@@ -223,7 +223,7 @@ function messageHandler (client, event) {
   }
 }
 
-// When doing singular operations and we retrieve and error this function will throw that error.
+// When doing singular operations and we retrieve an error this function will throw that error
 function processResponse (path, result) {
   const isSingularOperation = typeof path === 'string'
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -5,8 +5,10 @@ import Tracker from './tracker'
 import NativePromise from 'native-promise-only'
 
 const Promise = window.Promise || NativePromise
-const PROMISE_TIMEOUT = 10000
+export const PROMISE_TIMEOUT = 10000
 // 10 seconds, see ZD#4058685
+export const PROMISE_TIMEOUT_LONG = 5 * 60 * 1000
+// Set a high timeout threshold to allow us to better gauge the time taken for successful requests
 const NO_TIMEOUT_ACTIONS = ['instances.create']
 const ZAF_EVENT = /^zaf\./
 const pendingPromises = {}
@@ -21,8 +23,8 @@ window.Promise = Promise
 // Reject a request if required, given the rejection function, name (get, set or invoke)
 // and arguments to that request. Falls back to 10000 second timeout with few exceptions.
 //
-function timeoutReject (reject, name, client, paramsArray) {
-  const actions = paramsArray.map(action => `${name}-${action}`)
+function timeoutReject (client, reject, name, paramsArray) {
+  const actions = collateActions(name, paramsArray)
   switch (name) {
     case 'invoke': {
       const matches = paramsArray.filter((action) => {
@@ -45,6 +47,15 @@ function timeoutReject (reject, name, client, paramsArray) {
   }
 }
 
+function defaultTimer (client, actions, callback) {
+  return setTimeout(() => {
+    trackSDKRequestTimeout(client, actions, PROMISE_TIMEOUT_LONG)
+    callback(new Error('Invocation request timeout'))
+  }, PROMISE_TIMEOUT_LONG)
+}
+
+export function collateActions (name, params) { return params.map(action => `${name}-${action}`) }
+
 export function stripActionArgs (action) {
   // Capture:
   // 1. single or multiple comma-delimited arguments following an initial colon, and
@@ -54,18 +65,21 @@ export function stripActionArgs (action) {
   return action.replace(ACTION_ARGS, ':arg$3')
 }
 
-function defaultTimer (client, actions, callback) {
-  const actionsTags = actions.map(action => `action:${stripActionArgs(action)}`)
-  return setTimeout(() => {
-    client.postMessage('__track__', {
-      event_name: 'sdk_request_timeout',
-      event_type: 'increment',
-      data: 1,
-      tags: actionsTags
-    })
+export function timeMsToSecondsRange (value, upperLimit = PROMISE_TIMEOUT_LONG) {
+  if (value >= upperLimit) return `${upperLimit / 1000}-`
+  const lowerRangeBound = value - (value % 10000)
+  return `${lowerRangeBound / 1000}-${(lowerRangeBound + 10000) / 1000}`
+}
 
-    callback(new Error('Invocation request timeout'))
-  }, PROMISE_TIMEOUT)
+export function trackSDKRequestTimeout (client, actions, requestResponseTime) {
+  const actionsTags = actions.map(action => `action:${stripActionArgs(action)}`)
+  const responseTimeTag = `request_response_time:${timeMsToSecondsRange(requestResponseTime)}`
+  client.postMessage('__track__', {
+    event_name: 'sdk_request_timeout',
+    event_type: 'increment',
+    data: 1,
+    tags: actionsTags.concat(responseTimeTag)
+  })
 }
 
 function nextIdFor (name) {
@@ -102,25 +116,40 @@ function rawPostMessage (client, msg, forceReady) {
 //
 function wrappedPostMessage (name, params) {
   const id = nextIdFor('promise')
-  let timeoutId
-  const promise = new Promise((resolve, reject) => {
-    // Time out the promise to ensure it will be garbage collected if nobody responds
-    timeoutId = timeoutReject(reject, name, this, Array.isArray(params) ? params : Object.keys(params))
+  let timeoutId, promiseStartTime
+  const paramsArray = Array.isArray(params) ? params : Object.keys(params)
+  const actions = collateActions(name, paramsArray)
+  const client = this
 
-    pendingPromises[id] = { resolve: resolve, reject: reject }
+  const promise = new Promise((resolve, reject) => {
+    promiseStartTime = window.performance.now()
+
+    // Time out the promise to ensure it will be garbage collected if nobody responds
+    timeoutId = timeoutReject(client, reject, name, paramsArray)
+    pendingPromises[id] = { resolve, reject }
 
     const msg = JSON.stringify({
       id: id,
       request: name,
       params: params,
-      appGuid: this._appGuid,
-      instanceGuid: this._instanceGuid
+      appGuid: client._appGuid,
+      instanceGuid: client._instanceGuid
     })
-    rawPostMessage(this, msg)
+    rawPostMessage(client, msg)
   })
 
-  // ensure promise is cleaned up when resolved
-  return promise.then(removePromise.bind(null, id, timeoutId), removePromise.bind(null, id, timeoutId))
+  const trackTimeoutWithResolutionTime = () => {
+    const promiseResolutionTime = window.performance.now() - promiseStartTime
+    if (promiseResolutionTime > PROMISE_TIMEOUT) {
+      trackSDKRequestTimeout(client, actions, promiseResolutionTime)
+    }
+  }
+
+  // ensure promise is cleaned up when resolved/rejected, track request performance for resolved promises
+  return promise.then(
+    removePromise.bind(null, { id, timeoutId, trackTimeoutWithResolutionTime }),
+    removePromise.bind(null, { id, timeoutId })
+  )
 }
 
 function createError (error) {
@@ -131,9 +160,10 @@ function createError (error) {
   return err
 }
 
-function removePromise (id, timeoutId, args) {
-  clearTimeout(timeoutId)
-  delete pendingPromises[id]
+function removePromise (options, args) {
+  clearTimeout(options.timeoutId)
+  delete pendingPromises[options.id]
+  options.trackTimeoutWithResolutionTime && options.trackTimeoutWithResolutionTime()
   if (args instanceof Error) throw args
   return args
 }


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description
Extends the SDK request timeout to 5 minutes, and adds instrumentation to track the time taken to resolve every request longer than 10 seconds.

Measured times are grouped into 10 second ranges to ensure tags sent to Datadog are bounded.

### References
* JIRA: https://zendesk.atlassian.net/browse/AF-1528

### Risks
* Low - Datadog tracking for `sdk_request_timeout` fails because of errors in tag strings.