### PR TITLE
[AF-1548] [POC] Pause request timeout timers in background tabs

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1,18 +1,19 @@
 /* global URL */
 import version from 'version'
-import { when, isObject, isString } from './utils'
+import { when, isObject, isString, PausableTimer } from './utils'
 import Tracker from './tracker'
 import NativePromise from 'native-promise-only'
 
 const Promise = window.Promise || NativePromise
 export const PROMISE_TIMEOUT = 10000
 // 10 seconds, see ZD#4058685
-export const PROMISE_TIMEOUT_LONG = 5 * 60 * 1000
+export const PROMISE_TIMEOUT_LONG = 30000
 // Set a high timeout threshold to allow us to better gauge the time taken for successful requests
 const NO_TIMEOUT_ACTIONS = ['instances.create']
 const ZAF_EVENT = /^zaf\./
 const pendingPromises = {}
 const ids = {}
+let requestTimers = []
 
 // // export Promise!
 window.Promise = Promise
@@ -48,10 +49,12 @@ function timeoutReject (client, reject, name, paramsArray) {
 }
 
 function defaultTimer (client, actions, callback) {
-  return setTimeout(() => {
+  const timer = new PausableTimer(() => {
     trackSDKRequestTimeout(client, actions, PROMISE_TIMEOUT_LONG)
     callback(new Error('Invocation request timeout'))
   }, PROMISE_TIMEOUT_LONG)
+  requestTimers.push(timer)
+  return timer
 }
 
 export function collateActions (name, params) { return params.map(action => `${name}-${action}`) }
@@ -294,6 +297,11 @@ function isOriginValid (origin) {
   return false
 }
 
+function toggleRequestTimers (documentHidden, timers) {
+  const control = documentHidden ? 'pause' : 'resume'
+  timers.forEach((timer) => timer[control]())
+}
+
 export default class Client {
   constructor (options) {
     this._parent = options.parent
@@ -337,7 +345,10 @@ export default class Client {
 
     const tracker = new Tracker(this)
     tracker.setup()
+
+    window.addEventListener('visibilitychange', toggleRequestTimers(document.hidden, requestTimers))
     window.addEventListener('message', messageHandler.bind(null, this))
+
     this.postMessage('iframe.handshake', { version: version })
   }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -114,3 +114,20 @@ export function when (items) {
 
   return allResolvedPromise
 }
+
+export function PausableTimer (callback, delay) {
+  let timerId, start, remaining = delay
+
+  this.pause = () => {
+    window.clearTimeout(timerId)
+    remaining -= window.performance.now() - start
+  }
+
+  this.resume = () => {
+    start = window.performance.now()
+    window.clearTimeout(timerId)
+    timerId = window.setTimeout(callback, remaining)
+  }
+
+  this.resume()
+}


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description
1. Adds an event listener to know if a tab changes from foreground <-> background (see: https://developers.google.com/web/updates/2017/03/background_tabs);
2. Pauses/destroys the existing timers on transition to background tab;
3. Resumes/reinitiates the timers if the tab ever resurfaces a foreground tab.

### References
* JIRA: https://zendesk.atlassian.net/browse/AF-1548

### Risks
* TBD