### PR TITLE
[AF-1489] Update Fossa command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,6 @@ matrix:
       before_script:
         - curl -H 'Cache-Control:no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | BINDIR=$(pwd) bash
       script:
-        - ./fossa # analyze dependencies and upload them (fails when missing api key)
+        - ./fossa && ./fossa test # analyze and scan dependencies (fails when missing api key)
   allow_failures:
     - env: TASK=fossa

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Zendesk App Framework SDK
 =========================
 
 [![Build Status](https://travis-ci.org/zendesk/zendesk_app_framework_sdk.svg?branch=master)](https://travis-ci.org/zendesk/zendesk_app_framework_sdk)
-[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fzendesk%2Fzendesk_app_framework_sdk.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fzendesk%2Fzendesk_app_framework_sdk?ref=badge_shield)
+[![FOSSA Status](https://app.fossa.io/api/projects/custom%2B4071%2Fgithub.com%2Fzendesk%2Fzendesk_app_framework_sdk.svg?type=shield)](https://app.fossa.io/projects/custom%2B4071%2Fgithub.com%2Fzendesk%2Fzendesk_app_framework_sdk?ref=badge_shield)
 
 
 ## What is it?


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description
Update Fossa command to run `fossa test` as part of Travis check.

- `fossa` is the shorthand for `fossa init` then `fossa analyze`, which only gather information about dependencies of the project then upload that data to Fossa. This command doesn't run further checks or scans.
- `fossa test` triggers the actual scan based on the data provided by `fossa analyze` in the previous step. We only need to run this if `fossa analyze` completed successfully. This step would take a longer time than `analyze` (default timeout is 10 minutes which is unlikely to be hit based on their documentation) and would report exit status back to Travis once it's done.

### References
* JIRA: https://zendesk.atlassian.net/browse/AF-1489
* Slack: https://zendesk.slack.com/archives/CHCQYJ468/p1561516891013900

### Risks
* None. This change only affects our internal build pipeline.