### PR TITLE
Fix tesco regex

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -288,7 +288,7 @@ function isOriginValid (origin) {
       /^https:\/\/.+\.cloudhatchery\.com$/,
       /^https:\/\/.+\.idealwith\.com$/,
       // Tesco domains:
-      /^https:\/\/.+\.ourtesco.com$/
+      /^https:\/\/.+\.ourtesco\.com$/
     ]
 
     for (let i = 0; i < WHITELISTED_ORIGINS.length; i++) {


### PR DESCRIPTION
The regex was insecure as we missed to skip the wildcard character `.`

This would not result in an issue immediately as `ourtescoxcom`(any character in place of that x will do) is not a top level domain available atm, but someone can potentially buy it if they want.

The old regex will match something like this too: https://test.chrisg.ourtescoocom

@zendesk/vegemite 

### Risk
High. We may break apps for our customers who are using apps on unexpected domains.