### PR TITLE
Update node-setup action

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - uses: zendesk/checkout@v2
-      - uses: zendesk/setup-node@v2.0.0
+      - uses: zendesk/setup-node@v2.1.2
         with:
           node-version: 12.10.0
       - name: install npm modules


### PR DESCRIPTION
Update node setup action so that all builds pass. At the moment node setup fails because Github has deprecated set-env and add-path commands 
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/