### PR TITLE
Add a allowOrigin option to bypass invalid origins

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -326,6 +326,7 @@ export default class Client {
     this._source = options.source || (this._parent && this._parent._source) || window.parent
     this._appGuid = options.appGuid || (this._parent && this._parent._appGuid)
     this._instanceGuid = options.instanceGuid || this._appGuid
+    this._allowOrigin = options.allowOrigin || false
     this._messageHandlers = {}
     this._repliesPending = {}
     this._instanceClients = {}
@@ -335,7 +336,7 @@ export default class Client {
     this._idleState = null
     this.ready = false
 
-    if (!isOriginValid(this._origin)) {
+    if (!this._allowOrigin && !isOriginValid(this._origin)) {
       const originHostname = new URL(this._origin).hostname
       this.postMessage('__track__', {
         event_name: 'invalid_sdk_origin',

--- a/lib/index.js
+++ b/lib/index.js
@@ -27,15 +27,17 @@ import { queryParameters } from './utils'
  */
 
 const ZAFClient = {
-  init: function (callback, loc) {
+  init: function (callback, loc, options) {
     loc = loc || window.location
+    options = options || {}
+    const allowOrigin = options.allowOrigin
     const queryParams = queryParameters(loc.search)
     const hashParams = queryParameters(loc.hash)
     const origin = queryParams.origin || hashParams.origin
     const appGuid = queryParams.app_guid || hashParams.app_guid
     if (!origin || !appGuid) { return false }
 
-    const client = new Client({ origin, appGuid })
+    const client = new Client({ origin, appGuid, allowOrigin })
 
     if (typeof callback === 'function') {
       client.on('app.registered', callback.bind(client))

--- a/spec/client_spec.js
+++ b/spec/client_spec.js
@@ -177,6 +177,17 @@ describe('Client', () => {
         expect(ACTUAL_ERROR_MSG).to.equal(EXPECTED_ERROR_MSG)
       })
     })
+
+    it('does not clear the iframe and append an error msg when allowOrigin is true', () => {
+      const validOriginClient = new Client({
+        origin: 'https://hostmapped.com',
+        appGuid: 'appGuid',
+        source: source,
+        allowOrigin: true
+      })
+
+      expect(validOriginClient).to.exist()
+    })
   })
 
   describe('initialisation', () => {


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description

In Guide (Help Center) we have successfully built a POC for an enduser app using `zaf`, `zaf_sdk` and `zcli`. We are now doing a final push to release this app in an EAP.

As we talked about in one of our last meetings, Help Center supports host-mapped domains and this is currently leading to `Invalid domain [origin]` error screens. In this PR we're following your recommendation to introduce a way to bypass this check.

We understand this allow list was added in https://github.com/zendesk/zendesk_app_framework_sdk/pull/58 to address a [security vulnerability](https://zendesk.slack.com/archives/C371P4Y3S/p1582088550425200) so I'm thinking that, even thought left undocumented, this solution might reopen that vulnerability.

We'd really appreciate your feedback here 🙏🏼 
Alternatively, help us think of another way to have this available only in Help Center.


### Tasks
- [ ] Include comments/inline docs where appropriate
- [ ] Add [unit tests](/spec)
- [ ] Update changelog [here](https://github.com/zendesk/zaf_docs/blob/master/doc/v2/dev_guide/changelog.md)

### References
* JIRA: https://zendesk.atlassian.net/browse/VEG-XXX

### DevQA Steps

<!-- The DevQA process is to assess whether the work meets its acceptance criteria. If the acceptance criteria are unclear, the DevQA should verify with the code owner or the person who created the Jira card. To start with DevQA, deploy this branch to [staging](https://samson.zende.sk/projects/zendesk_app_framework/stages/static-assets-build) environment. -->

- Make sure [Zendesk Apps Framework regression tests](https://zendesk.atlassian.net/wiki/spaces/ENG/pages/641702848/DevQA+process+in+Vegemite#DevQAprocessinVegemite-regression-checks) are passing with this change.
- Add specific DevQA instructions here ....

NOTE: DevQA steps are to be actioned only once code has been reviewed and approved.

### Risks
* [HIGH | medium | low] Does it work across browsers (including IE!)?
* [HIGH | medium | low] Does it work in the different products (Support, Chat, Connect)?
* [HIGH | medium | low] Are there any performance implications?
* [HIGH | medium | low] Any security risks?
* [HIGH | medium | low] What features does this touch?

### Rollback Plan

1. Quickly [roll back] to the prior release so that customers can refresh to resolve their issue.
1. Revert this PR to restore the master branch to a deployable green state.
1. Notify the author.

[roll back]: https://github.com/zendesk/zendesk_app_framework_sdk/blob/master/DEPLOY.md#recovery

<!--
List any additional tasks to perform if this PR is reverted. Examples:
 * Run a backfill to alter changed data structures
 * Roll back state of any co-dependent feature flags
 * Revert a PR changing an API endpoint in another repo
 * Inform particular customers, PMs, and/or stakeholders
 * Note any non-obvious consequence of reversion
-->
