### PR TITLE
[VEG-1180][VEG-1168] Support end user apps POC

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -291,7 +291,9 @@ function isOriginValid (origin) {
       /^https:\/\/.+\.cloudhatchery\.com$/,
       /^https:\/\/.+\.idealwith\.com$/,
       // Tesco domains:
-      /^https:\/\/.+\.ourtesco\.com$/
+      /^https:\/\/.+\.ourtesco\.com$/,
+      // Dynamically populated domains associated to hostmapped domains.
+      ...this._hostmappedDomains
     ]
 
     for (let i = 0; i < WHITELISTED_ORIGINS.length; i++) {
@@ -320,19 +322,22 @@ function appendErrorToBody (errorMsg) {
 }
 
 export default class Client {
+  // Values in the constructor are set either by passing queryParams to the iframe url on render by ZAF,
+  // or by assigning appropriate attributes to the parent iframe on render.
   constructor (options) {
-    this._parent = options.parent
-    this._origin = options.origin || (this._parent && this._parent._origin)
-    this._source = options.source || (this._parent && this._parent._source) || window.parent
     this._appGuid = options.appGuid || (this._parent && this._parent._appGuid)
+    this._context = options.context || null
+    this._hostmappedDomains = options.hostmappedDomains || this._parent._hostmappedDomains
+    this._idleState = null
+    this._iframe_session_timeout = options.iframe_session_timeout || IFRAME_SESSION_TIMEOUT
+    this._instanceClients = {}
     this._instanceGuid = options.instanceGuid || this._appGuid
     this._messageHandlers = {}
-    this._repliesPending = {}
-    this._instanceClients = {}
     this._metadata = null
-    this._context = options.context || null
-    this._iframe_session_timeout = options.iframe_session_timeout || IFRAME_SESSION_TIMEOUT
-    this._idleState = null
+    this._origin = options.origin || (this._parent && this._parent._origin)
+    this._parent = options.parent
+    this._repliesPending = {}
+    this._source = options.source || (this._parent && this._parent._source) || window.parent
     this.ready = false
 
     if (!isOriginValid(this._origin)) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -29,13 +29,15 @@ import { queryParameters } from './utils'
 const ZAFClient = {
   init: function (callback, loc) {
     loc = loc || window.location
+    // These queryParams are set within ZAF when the iframe is rendered.
     const queryParams = queryParameters(loc.search)
     const hashParams = queryParameters(loc.hash)
     const origin = queryParams.origin || hashParams.origin
     const appGuid = queryParams.app_guid || hashParams.app_guid
+    const hostmappedDomains = queryParams.hostmappedDomains || hashParams.hostmappedDomains
     if (!origin || !appGuid) { return false }
 
-    const client = new Client({ origin, appGuid })
+    const client = new Client({ origin, appGuid, hostmappedDomains })
 
     if (typeof callback === 'function') {
       client.on('app.registered', callback.bind(client))


### PR DESCRIPTION
🚧  Work in progress, nothing to see here, move along ... 🚧 

:v:

/cc @zendesk/vegemite

### Description
Guide would like to add support for end user apps within the zaf_sdk.  This change is about looking into doing that securely.

### Tasks
- [ ] Include comments/inline docs where appropriate
- [ ] Add [unit tests](/spec)
- [ ] Update changelog [here](https://github.com/zendesk/zaf_docs/blob/master/doc/v2/dev_guide/changelog.md)

### References
* JIRA: https://zendesk.atlassian.net/browse/VEG-XXX

### DevQA Steps

<!-- The DevQA process is to assess whether the work meets its acceptance criteria. If the acceptance criteria are unclear, the DevQA should verify with the code owner or the person who created the Jira card. To start with DevQA, deploy this branch to [staging](https://samson.zende.sk/projects/zendesk_app_framework/stages/static-assets-build) environment. -->

- Make sure [Zendesk Apps Framework regression tests](https://zendesk.atlassian.net/wiki/spaces/ENG/pages/641702848/DevQA+process+in+Vegemite#DevQAprocessinVegemite-regression-checks) are passing with this change.
- Add specific DevQA instructions here ....

NOTE: DevQA steps are to be actioned only once code has been reviewed and approved.

### Risks
* Medium. Adds an initialisation attribute (albeit optional) to the zaf_sdk for each runningApp object.

### Rollback Plan

1. Quickly [roll back] to the prior release so that customers can refresh to resolve their issue.
1. Revert this PR to restore the master branch to a deployable green state.
1. Notify the author.

[roll back]: https://github.com/zendesk/zendesk_app_framework_sdk/blob/master/DEPLOY.md#recovery

<!--
List any additional tasks to perform if this PR is reverted. Examples:
 * Run a backfill to alter changed data structures
 * Roll back state of any co-dependent feature flags
 * Revert a PR changing an API endpoint in another repo
 * Inform particular customers, PMs, and/or stakeholders
 * Note any non-obvious consequence of reversion
-->
