### PR TITLE
Add package guard GA

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -6,6 +6,21 @@ on:
     - master
 
 jobs:
+  dependency-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Block dependencies from being added to package.json
+        run: |
+          IFS=' ' read -r allowed <<< "native-promise-only zendesk_app_framework_sdk"
+          dependencies=$(npm ls --production --depth=0 --parseable | awk '{gsub(/\/.*\//,"",$1); print}')
+
+          for dep in $dependencies; do
+            if [[ ! ${allowed[*]} =~ (^|[[:space:]])"$dep"($|[[:space:]]) ]]; then
+              echo "::error ZAP SDK does not allow external dependencies, please remove \"${dep}\" dependency from package.json"
+              exit 1
+            fi
+          done
+        shell: bash
   main-job:
     runs-on: ubuntu-latest
     strategy:

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+set -euo pipefail
+IFS=' ' read -r allowed <<< "native-promise-only zendesk_app_framework_sdk"
+dependencies=$(npm ls --production --depth=0 --parseable | awk '{gsub(/\/.*\//,"",$1); print}')
+
+for dep in $dependencies; do
+  if [[ ! ${allowed[*]} =~ (^|[[:space:]])"$dep"($|[[:space:]]) ]]; then
+    echo "::error ZAP SDK does not allow external dependencies, please remove \"${dep}\" dependency from package.json"
+    exit 1
+  fi
+done
+
+# for dep in $dependencies; do
+#   found="" 
+#   for allow in $allowed[@]; do
+#     if [[ ${allow} == ${dep} ]]; then
+#       found=$allow
+#       continue
+#     fi
+#   done
+#   if [[ -z "$found" ]]; then
+#     echo "::error ZAP SDK does not allow external dependencies, please remove \"${dep}\" dependency from package.json"
+#     exit 1
+#   fi
+# done
+
+
+# for dep in $dependencies; do
+#   found="" 
+#   for allow in $allowed[@]; do if [[ ${allow} == ${dep} ]]; then found=$allow continue fi done
+#   if [[ -z "$found" ]]; then
+#     echo "::error ZAP SDK does not allow external dependencies, please remove \"${dep}\" dependency from package.json"
+#     exit 1
+#   fi
+# done


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description
Dependencies which pollute the global in javascript can cause conflicts with versions of libraries used by app developers within their apps. Therefore, to mitigate the risk of conflicts, we would like to identify a way to prevent dependencies from being added to ZAF_SDK unintentionally.

### References
* JIRA: https://zendesk.atlassian.net/browse/VEG-1466

### Risks
* [low] We just changing the GA to prevent adding dependancies

### Rollback Plan

1. Quickly [roll back] to the prior release so that customers can refresh to resolve their issue.
1. Revert this PR to restore the master branch to a deployable green state.
1. Notify the author.

[roll back]: https://github.com/zendesk/zendesk_app_framework_sdk/blob/master/DEPLOY.md#recovery

<!--
List any additional tasks to perform if this PR is reverted. Examples:
 * Run a backfill to alter changed data structures
 * Roll back state of any co-dependent feature flags
 * Revert a PR changing an API endpoint in another repo
 * Inform particular customers, PMs, and/or stakeholders
 * Note any non-obvious consequence of reversion
-->
