### PR TITLE
ci: enable manual pre-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,40 @@
 name: release
 
 on:
+  workflow_dispatch:
   pull_request:
     types: [closed]
 
 jobs:
+  pre-release:
+    name: Create Pre Release
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      # Check out the `master` branch
+      - uses: zendesk/checkout@v3
+      # Compute the next semantic version
+      - name: Compute release tag
+        id: compute_tag
+        uses: zendesk/compute-tag@v10
+        with:
+          github_token: ${{ github.token }}
+          version_scheme: semantic
+          version_type: prerelease
+      - name: Create release
+        id: create_release
+        uses: zendesk/create-release@v1.1.4
+        with:
+          tag_name: ${{ steps.compute_tag.outputs.next_tag }}
+          release_name: ${{ steps.compute_tag.outputs.next_tag }}
+          commitish: ${{ github.git_ref }}
+          body: |
+            This is a pre-release.
+            See [changes since last release](https://github.com/${{ github.repository }}/compare/${{ steps.compute_tag.outputs.previous_tag }}..${{ steps.compute_tag.outputs.next_tag }}) for full release details.
+          prerelease: true
+          draft: false
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
   patch-release:
     name: Create Patch Release
     if: (github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'patch') )


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description
enable manual pre-release

### Tasks
- [ ] Include comments/inline docs where appropriate
- [ ] Add [unit tests](/spec)
- [ ] Update changelog [here](https://github.com/zendesk/zaf_docs/blob/master/doc/v2/dev_guide/changelog.md)
- [ ] Add label from one of 'patch'/'minor'/'major' if you want to create a release when merged

### References
* JIRA: https://zendesk.atlassian.net/browse/VEG-2717

### DevQA Steps

<!-- The DevQA process is to assess whether the work meets its acceptance criteria. If the acceptance criteria are unclear, the DevQA should verify with the code owner or the person who created the Jira card. To start with DevQA, deploy this branch to [staging](https://samson.zende.sk/projects/zendesk_app_framework/stages/static-assets-build) environment. -->

- Make sure [Zendesk Apps Framework regression tests](https://zendesk.atlassian.net/wiki/spaces/ENG/pages/641702848/DevQA+process+in+Vegemite#DevQAprocessinVegemite-regression-checks) are passing with this change.
- Add specific DevQA instructions here ....

NOTE: DevQA steps are to be actioned only once code has been reviewed and approved.

### Risks
* Low: ci changes only

### Rollback Plan

1. Quickly [roll back] to the prior release so that customers can refresh to resolve their issue.
1. Revert this PR to restore the master branch to a deployable green state.
1. Notify the author.

[roll back]: https://github.com/zendesk/zendesk_app_framework_sdk/blob/master/DEPLOY.md#recovery

<!--
List any additional tasks to perform if this PR is reverted. Examples:
 * Run a backfill to alter changed data structures
 * Roll back state of any co-dependent feature flags
 * Revert a PR changing an API endpoint in another repo
 * Inform particular customers, PMs, and/or stakeholders
 * Note any non-obvious consequence of reversion
-->
