### PR TITLE
Replace vegemite references to wattle

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -10,7 +10,7 @@ To roll back to a previous version, use the [App Framework SDK deploys](https://
 
 _Note: This pipeline should **only** be used to respond to incidents._
 
-1. Notify @vegemite on #ask-vegemite of any ongoing incidents and whether you intend to rollback a deploy.
+1. Notify @wattle on #wattle-team of any ongoing incidents and whether you intend to rollback a deploy.
 1. Look at recent [App Framework SDK deploys](https://samson.zende.sk/projects/zendesk_app_framework_sdk/stages/static-assets-switch-major) to production.
 1. Deploy the previous tag.
-1. Notify @vegemite on #ask-vegemite once the rollback is complete.
+1. Notify @wattle on #wattle-team once the rollback is complete.


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite @zendesk/wattle

### Description
As per this [re-org announcement](https://zendesk.slack.com/archives/C082LS1HM3M/p1732659075201119), Wattle is taking ownership of ZAF/ZCLI and related projects. This PR updates the repo to reflect those changes.

* [low] Just a doc change

### Rollback Plan

1. Quickly [roll back] to the prior release so that customers can refresh to resolve their issue.
1. Revert this PR to restore the master branch to a deployable green state.
1. Notify the author.

[roll back]: https://github.com/zendesk/zendesk_app_framework_sdk/blob/master/DEPLOY.md#recovery

<!--
List any additional tasks to perform if this PR is reverted. Examples:
 * Run a backfill to alter changed data structures
 * Roll back state of any co-dependent feature flags
 * Revert a PR changing an API endpoint in another repo
 * Inform particular customers, PMs, and/or stakeholders
 * Note any non-obvious consequence of reversion
-->
